### PR TITLE
cats 1.0.0-MF, scalacheck 1.13.5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 project/*
-target/*
+target/

--- a/README.md
+++ b/README.md
@@ -13,13 +13,13 @@ object HelloWorld extends CommandApp(
   name = "hello-world",
   header = "Says hello!",
   main = {
-    val userOpt = 
+    val userOpt =
       Opts.option[String]("target", help = "Person to greet.")
         .withDefault("world")
-    
+
     val quietOpt = Opts.flag("quiet", help = "Whether to be quiet.").orFalse
 
-    (userOpt |@| quietOpt).map { (user, quiet) => 
+    (userOpt, quietOpt).mapN { (user, quiet) => 
 
       if (quiet) println("...")
       else println(s"Hello $user!")
@@ -33,4 +33,3 @@ object HelloWorld extends CommandApp(
 [optparse]: https://github.com/pcapriotti/optparse-applicative
 [cats]: https://github.com/typelevel/cats
 [decline]: http://ben.kirw.in/decline/
-

--- a/build.sbt
+++ b/build.sbt
@@ -48,10 +48,11 @@ lazy val decline =
     .settings(
       name := "decline",
       description := "Composable command-line parsing for Scala",
-      libraryDependencies += "org.typelevel" %%% "cats" % "0.9.0",
+      libraryDependencies += "org.typelevel" %%% "cats-core" % "1.0.0-MF",
       libraryDependencies ++= Seq(
         "org.scalatest" %%% "scalatest" % "3.0.0" % "test",
-        "org.scalacheck" %%% "scalacheck" % "1.13.3" % "test"
+        "org.scalacheck" %%% "scalacheck" % "1.13.5" % "test",
+        "org.typelevel" %%% "cats-laws" % "1.0.0-MF" % "test"
       )
     )
 
@@ -74,4 +75,3 @@ lazy val doc =
       micrositeHighlightTheme := "solarized-light",
       micrositeDocumentationUrl := "usage.html"
     )
-

--- a/core/jvm/src/test/scala/com/monovore/example/decline/Git.scala
+++ b/core/jvm/src/test/scala/com/monovore/example/decline/Git.scala
@@ -18,7 +18,7 @@ object Git extends CommandApp(
 
       val message = Opts.option[String]("message", short = "m", help = "Commit message").orNone
 
-      (all |@| message).tupled
+      (all, message).tupled
         .map { tuple => println("COMMIT " + tuple) }
     }
 

--- a/core/jvm/src/test/scala/com/monovore/example/decline/Link.scala
+++ b/core/jvm/src/test/scala/com/monovore/example/decline/Link.scala
@@ -18,7 +18,7 @@ object Link extends CommandApp(
     val first = {
       val nonDirectory = Opts.flag("no-target-directory", short = "T", help = "...").orFalse
 
-      (nonDirectory |@| target |@| linkName).map { (_, target, link) =>
+      (nonDirectory, target, linkName).mapN { (_, target, link) =>
         println(s"Create a link to $target with name $link.")
       }
     }
@@ -28,14 +28,14 @@ object Link extends CommandApp(
     }
 
     val third =
-      (targets |@| directory).map { (targets, dir) =>
+      (targets, directory).mapN { (targets, dir) =>
         println(s"Create links in $dir to: ${targets.toList.mkString(", ")}")
       }
 
     val fourth = {
       val isDirectory = Opts.option[Path]("target-directory", short = "t", help = "...")
 
-      (isDirectory |@| targets).map { (dir, targets) =>
+      (isDirectory, targets).mapN { (dir, targets) =>
         println(s"Create links in $dir to: ${targets.toList.mkString(", ")}")
       }
     }

--- a/core/jvm/src/test/scala/com/monovore/example/decline/ListDir.scala
+++ b/core/jvm/src/test/scala/com/monovore/example/decline/ListDir.scala
@@ -19,7 +19,7 @@ object ListDir extends CommandApp(
 
     val directory = Opts.arguments[String]("directory").orEmpty
 
-    (color |@| all |@| directory).map { (color, all, directory) =>
+    (color, all, directory).mapN { (color, all, directory) =>
 
       println("Color: "  + color)
       println("All: "  + all)

--- a/core/jvm/src/test/scala/com/monovore/example/decline/ScoptExample.scala
+++ b/core/jvm/src/test/scala/com/monovore/example/decline/ScoptExample.scala
@@ -25,7 +25,7 @@ object ScoptExample extends CommandApp(
         Opts.option[Int]("max", help = "Limit for --libname option.")
           .validate("Specified max must be positive.") { _ > 0 }
 
-      (libname |@| max).tupled.orNone
+      (libname, max).tupled.orNone
     }
 
     val jars = Opts.options[Path]("jar", short = "j", help = "Jar to include! More args, more jars.").orEmpty
@@ -48,12 +48,12 @@ object ScoptExample extends CommandApp(
       val xyz = Opts.flag("xyz", help = "Boolean prop?").orFalse
       // SKIPPED: xyz as boolean, not flag
 
-      (keepalive |@| xyz).tupled
+      (keepalive, xyz).tupled
         .validate("Can't both keepalive and xyz!") { case (keepalive, xyz) => !(keepalive && xyz) }
     }
 
-    (foo |@| out |@| libMax |@| jars |@| verbose |@| debug |@| files |@| update)
-      .map { (foo, out, libMax, jars, verbose, debug, files, update) =>
+    (foo, out, libMax, jars, verbose, debug, files, update)
+      .mapN { (foo, out, libMax, jars, verbose, debug, files, update) =>
         println("foo: " + foo)
         println("out: " + out)
         println("libmax: " + libMax)

--- a/core/shared/src/main/scala/com/monovore/decline/Help.scala
+++ b/core/shared/src/main/scala/com/monovore/decline/Help.scala
@@ -59,7 +59,7 @@ object Help {
     case Opts.Pure(_) => Some(Nil)
     case Opts.Missing => None
     case Opts.HelpFlag(a) => optionList(a)
-    case Opts.App(f, a) => (optionList(f) |@| optionList(a)).map { _ ++ _ }
+    case Opts.App(f, a) => (optionList(f), optionList(a)).mapN { _ ++ _ }
     case Opts.OrElse(a, b) => optionList(a) |+| optionList(b)
     case Opts.Single(opt) => Some(List(opt -> false))
     case Opts.Repeated(opt) => Some(List(opt -> true))

--- a/core/shared/src/main/scala/com/monovore/decline/Parser.scala
+++ b/core/shared/src/main/scala/com/monovore/decline/Parser.scala
@@ -197,7 +197,7 @@ private[decline] object Parser {
           left.parseSub(command)
             .map { parser =>
               parser andThen { _.map { leftResult =>
-                (leftResult |@| right.result).map { _ apply _ }.mapValidated(identity)
+                (leftResult, right.result).mapN { _ apply _ }.mapValidated(identity)
               }}
             }
 
@@ -205,7 +205,7 @@ private[decline] object Parser {
           right.parseSub(command)
             .map { parser =>
               parser andThen { _.map { rightResult =>
-                (left.result |@| rightResult).map { _ apply _ }.mapValidated(identity)
+                (left.result, rightResult).mapN { _ apply _ }.mapValidated(identity)
               }}
             }
 

--- a/core/shared/src/test/scala/com/monovore/decline/HelpSpec.scala
+++ b/core/shared/src/test/scala/com/monovore/decline/HelpSpec.scala
@@ -21,7 +21,7 @@ class HelpSpec extends WordSpec with Matchers {
             Opts.argument[String]("task")
           }
 
-        (first |@| second |@| subcommands).tupled
+        (first, second, subcommands).tupled
       }
 
       Help.fromCommand(parser).toString should equal(
@@ -53,7 +53,7 @@ class HelpSpec extends WordSpec with Matchers {
       val empty = MonoidK[Opts].empty
 
       "right-absorb" in {
-        help(empty) should equal(help((foo |@| empty).tupled))
+        help(empty) should equal(help((foo, empty).tupled))
       }
 
       "left-distribute" in {
@@ -61,7 +61,7 @@ class HelpSpec extends WordSpec with Matchers {
       }
 
       "right-distribute" in {
-        help(((foo <+> bar) |@| baz).tupled) should equal(help((foo |@| baz).tupled <+> (bar |@| baz).tupled))
+        help(((foo <+> bar), baz).tupled) should equal(help((foo, baz).tupled <+> (bar, baz).tupled))
       }
     }
   }

--- a/doc/src/main/tut/index.md
+++ b/doc/src/main/tut/index.md
@@ -29,7 +29,7 @@ First, pull the library into your build. For `sbt`:
 ```scala
 // Artifacts are published to bintray.
 resolvers += Resolver.bintrayRepo("bkirwi", "maven")
- 
+
 // `decline` is available for both 2.11 and 2.12
 libraryDependencies += "com.monovore" %% "decline" % "0.2.2"
 ```
@@ -44,12 +44,12 @@ object HelloWorld extends CommandApp(
   name = "hello-world",
   header = "Says hello!",
   main = {
-    val userOpt = 
+    val userOpt =
       Opts.option[String]("target", help = "Person to greet.") .withDefault("world")
-    
+
     val quietOpt = Opts.flag("quiet", help = "Whether to be quiet.").orFalse
 
-    (userOpt |@| quietOpt).map { (user, quiet) => 
+    (userOpt, quietOpt).mapN { (user, quiet) => 
       if (quiet) println("...")
       else println(s"Hello $user!")
     }

--- a/doc/src/main/tut/usage.md
+++ b/doc/src/main/tut/usage.md
@@ -110,7 +110,7 @@ using `cats`' [applicative syntax](http://typelevel.org/cats/typeclasses/apply.h
 ```tut:book
 import cats.implicits._
 
-val tailOptions = (linesOrDefault |@| fileList).map { (n, files) =>
+val tailOptions = (linesOrDefault, fileList).mapN { (n, files) =>
   println(s"LOG: Printing the last $n lines from each file in $files!")
 }
 ```
@@ -189,7 +189,7 @@ it's often easier to just define everything inline:
 object Tail extends CommandApp(
   name = "tail",
   header = "Print the last few lines of one or more files.",
-  main = (linesOrDefault |@| fileList).map { (n, files) =>
+  main = (linesOrDefault, fileList).mapN { (n, files) =>
     println(s"LOG: Printing the last $n lines from each file in $files!")
   }
 )


### PR DESCRIPTION
This updates decline to cats 1.0.0-MF, which was trivial … it only required removing the deprecated `CartesianBuilder` syntax. Also updates to ScalaCheck 1.13.5 since 1.13.3 seems to have disappeared.

Many downstream cats libs are publishing milestones depending on 1.0.0-MF so we will all be ready when the final release happens. It would be great to see one from decline!
