### PR TITLE
Add support for refined types

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -37,7 +37,7 @@ lazy val noPublishSettings = Seq(
 
 lazy val root =
   project.in(file("."))
-    .aggregate(declineJS, declineJVM, doc)
+    .aggregate(declineJS, declineJVM, refinedJS, refinedJVM, doc)
     .settings(defaultSettings)
     .settings(noPublishSettings)
 
@@ -59,9 +59,22 @@ lazy val decline =
 lazy val declineJVM = decline.jvm
 lazy val declineJS = decline.js
 
+lazy val refined =
+  crossProject.crossType(CrossType.Pure).in(file("refined"))
+    .settings(defaultSettings)
+    .settings(
+      name := "refined",
+      moduleName := "decline-refined",
+      libraryDependencies += "eu.timepit" %%% "refined" % "0.8.2"
+    )
+    .dependsOn(decline % "compile->compile;test->test")
+
+lazy val refinedJVM = refined.jvm
+lazy val refinedJS = refined.js
+
 lazy val doc =
   project.in(file("doc"))
-    .dependsOn(declineJVM)
+    .dependsOn(declineJVM, refinedJVM)
     .enablePlugins(MicrositesPlugin)
     .settings(defaultSettings)
     .settings(noPublishSettings)

--- a/doc/src/main/tut/index.md
+++ b/doc/src/main/tut/index.md
@@ -28,7 +28,7 @@ First, pull the library into your build. For `sbt`:
 
 ```scala
 // `decline` is available for both 2.11 and 2.12
-libraryDependencies += "com.monovore" %% "decline" % "0.3.0"
+libraryDependencies += "com.monovore" %% "decline" % "0.4.0"
 ```
 
 Then, write a program:
@@ -46,7 +46,7 @@ object HelloWorld extends CommandApp(
 
     val quietOpt = Opts.flag("quiet", help = "Whether to be quiet.").orFalse
 
-    (userOpt, quietOpt).mapN { (user, quiet) => 
+    (userOpt, quietOpt).mapN { (user, quiet) =>
       if (quiet) println("...")
       else println(s"Hello $user!")
     }

--- a/doc/src/main/tut/refined.md
+++ b/doc/src/main/tut/refined.md
@@ -1,0 +1,63 @@
+---
+layout: docs
+title:  "Refined Argument types"
+position: 3
+---
+
+# Refined Argument Types
+
+Decline has support for [refined types](https://github.com/fthomas/refined) via the `decline-refined` module.
+Refined types add an extra layer of safety by decorating standard types with predicates that get validated
+automatically at compile time.
+
+Whilst in the case of command line arguments such validation can not happen at compile time since the values are
+not know at the moment of building the code, runtime validation can still be done right before any value of
+the command arguments is passed into the application logic, preventing the introduction of invalid values by the user.
+
+## Defining Refined Type Arguments
+
+To make use of the refined types add the following to your `build.sbt`:
+
+```scala
+libraryDependencies += "com.monovore" %% "decline-refined" % "0.4.0"
+```
+
+And now we need to add a series of imports into our current scope:
+
+```tut:silent
+import com.monovore.decline._
+import com.monovore.decline.refined._
+import eu.timepit.refined.api.Refined
+import eu.timepit.refined.auto._
+import eu.timepit.refined.numeric.Positive
+```
+
+Following there is a very simple example of a numeric option which needs to be positive. We start by defining
+a new type that can only hold positive integers:
+
+```tut:book
+type PosInt = Int Refined Positive
+```
+
+And now we define an option parameterised on that specific type and a command so we can test it:
+
+```tut:book
+val lines = Opts.option[PosInt]("lines", short = "n", metavar = "count", help = "Set a number of lines.")
+val cmd = Command("echoLines", "Echoes the number of lines")(lines)
+```
+
+If we now try to parse a command line in which we have a `--lines 10` argument pair we should be able to parse
+the `lines` option:
+
+```tut:book
+cmd.parse(Seq("--lines", "10"))
+```
+
+However if we pass a 0 or a non positive value, the `parse` operation should fail:
+
+```tut:book
+cmd.parse(Seq("--lines", "0"))
+```
+
+Check the documentation for [refined](https://github.com/fthomas/refined) to see how you can define your own
+refined types.

--- a/refined/src/main/scala/com/monovore/decline/refined/package.scala
+++ b/refined/src/main/scala/com/monovore/decline/refined/package.scala
@@ -1,0 +1,33 @@
+package com.monovore.decline
+
+import cats.data.{Validated, ValidatedNel}
+import eu.timepit.refined.api.{RefType, Validate}
+
+package object refined {
+
+  implicit def refTypeArgument[F[_, _], T, P](
+      implicit argument: Argument[T],
+      refType: RefType[F],
+      validate: Validate[T, P]
+  ): Argument[F[T, P]] = new Argument[F[T, P]] {
+
+    override def defaultMetavar: String = argument.defaultMetavar
+
+    override def read(string: String): ValidatedNel[String, F[T, P]] =
+      argument.read(string) match {
+        case Validated.Valid(t) =>
+          refType.refine[P](t) match {
+            case Left(reason) =>
+              Validated.invalidNel(reason)
+
+            case Right(refined) =>
+              Validated.validNel(refined)
+          }
+
+        case Validated.Invalid(errs) =>
+          Validated.invalid(errs)
+      }
+
+  }
+
+}

--- a/refined/src/test/scala/com/monovore/decline/refined/RefinedArgumentSpec.scala
+++ b/refined/src/test/scala/com/monovore/decline/refined/RefinedArgumentSpec.scala
@@ -1,0 +1,29 @@
+package com.monovore.decline
+package refined
+
+import cats.data.Validated
+
+import eu.timepit.refined.api.Refined
+import eu.timepit.refined.auto._
+import eu.timepit.refined.numeric.Positive
+
+import org.scalacheck.Gen
+import org.scalatest.{Matchers, FlatSpec}
+
+class RefinedArgumentSpec extends FlatSpec with Matchers {
+
+  type PosInt = Int Refined Positive
+
+  "Argument[PosInt]" should "parse positive integers" in {
+    Argument[PosInt].read("1") shouldBe Validated.validNel(1: PosInt)
+  }
+
+  it should "not accept zero" in {
+    Argument[PosInt].read("0") shouldBe Validated.invalidNel("Predicate failed: (0 > 0).")
+  }
+
+  it should "not accept values that not numbers" in {
+    Argument[PosInt].read("abc") shouldBe Validated.invalidNel("Invalid integer: abc")
+  }
+
+}


### PR DESCRIPTION
This PR adds support for refined types via the Scala library [refined](https://github.com/fthomas/refined)