### PR TITLE
Add Metavar[A] type class to provide default metavar names.

### DIFF
--- a/core/js/src/main/scala/com/monovore/decline/PlatformMetavars.scala
+++ b/core/js/src/main/scala/com/monovore/decline/PlatformMetavars.scala
@@ -1,0 +1,5 @@
+package com.monovore.decline
+
+private[decline] abstract class PlatformMetavars {
+
+}

--- a/core/jvm/src/main/scala/com/monovore/decline/PlatformArguments.scala
+++ b/core/jvm/src/main/scala/com/monovore/decline/PlatformArguments.scala
@@ -1,15 +1,22 @@
 package com.monovore.decline
 
 import java.nio.file.{InvalidPathException, Path, Paths}
+import java.net.{URL, MalformedURLException}
 
 import cats.data.{Validated, ValidatedNel}
 
 private[decline] abstract class PlatformArguments {
 
-  implicit val readPath: Argument[Path] = new Argument[Path] {
+  implicit lazy val readPath: Argument[Path] =
+    Argument.instance { s =>
+      try { Validated.valid(Paths.get(s)) }
+      catch { case ipe: InvalidPathException => Validated.invalidNel(s"Invalid path: $s (${ ipe.getReason })") }
+    }
 
-    override def read(string: String): ValidatedNel[String, Path] =
-      try { Validated.valid(Paths.get(string)) }
-      catch { case ipe: InvalidPathException => Validated.invalidNel(s"Invalid path: $string (${ ipe.getReason })") }
-  }
+  implicit lazy val readURL: Argument[URL] =
+    Argument.instance { s =>
+      try { Validated.valid(new URL(s)) }
+      catch { case use: MalformedURLException => Validated.invalidNel(s"Invalid URL: $s (${ use.getMessage })") }
+    }
+
 }

--- a/core/jvm/src/main/scala/com/monovore/decline/PlatformArguments.scala
+++ b/core/jvm/src/main/scala/com/monovore/decline/PlatformArguments.scala
@@ -11,7 +11,5 @@ private[decline] abstract class PlatformArguments {
     override def read(string: String): ValidatedNel[String, Path] =
       try { Validated.valid(Paths.get(string)) }
       catch { case ipe: InvalidPathException => Validated.invalidNel(s"Invalid path: $string (${ ipe.getReason })") }
-
-    override def defaultMetavar: String = "path"
   }
 }

--- a/core/jvm/src/main/scala/com/monovore/decline/PlatformMetavars.scala
+++ b/core/jvm/src/main/scala/com/monovore/decline/PlatformMetavars.scala
@@ -1,0 +1,7 @@
+package com.monovore.decline
+
+import java.nio.file.Path
+
+private[decline] abstract class PlatformMetavars {
+  implicit lazy val pathMetavar = Metavar.instance[Path]("path")
+}

--- a/core/shared/src/main/scala/com/monovore/decline/Argument.scala
+++ b/core/shared/src/main/scala/com/monovore/decline/Argument.scala
@@ -5,7 +5,6 @@ import java.net.{URI, URISyntaxException}
 import cats.data.{Validated, ValidatedNel}
 
 trait Argument[A] { self =>
-  def defaultMetavar: String
   def read(string: String): ValidatedNel[String, A]
 }
 
@@ -16,16 +15,12 @@ object Argument extends PlatformArguments {
   implicit val readString: Argument[String] = new Argument[String] {
 
     override def read(string: String): ValidatedNel[String, String] = Validated.valid(string)
-
-    override def defaultMetavar: String = "string"
   }
 
   private def readNum[A](typeName: String)(parse: String => A): Argument[A] = new Argument[A] {
     override def read(string: String): ValidatedNel[String, A] =
       try Validated.valid(parse(string))
       catch { case nfe: NumberFormatException => Validated.invalidNel(s"Invalid $typeName: $string") }
-
-    override def defaultMetavar: String = typeName
   }
 
   implicit val readInt: Argument[Int] = readNum("integer")(_.toInt)
@@ -40,7 +35,5 @@ object Argument extends PlatformArguments {
     override def read(string: String): ValidatedNel[String, URI] =
       try { Validated.valid(new URI(string)) }
       catch { case use: URISyntaxException => Validated.invalidNel(s"Invalid URI: $string (${ use.getReason })") }
-
-    override def defaultMetavar: String = "uri"
   }
 }

--- a/core/shared/src/main/scala/com/monovore/decline/Argument.scala
+++ b/core/shared/src/main/scala/com/monovore/decline/Argument.scala
@@ -1,8 +1,7 @@
 package com.monovore.decline
 
 import cats.data.{Validated, ValidatedNel}
-import java.net.{URI, URISyntaxException, URL, MalformedURLException}
-import java.nio.file.{FileSystems, InvalidPathException, Path}
+import java.net.{URI, URISyntaxException}
 import java.util.UUID
 import scala.concurrent.duration.Duration
 
@@ -68,21 +67,9 @@ object Argument extends PlatformArguments {
       catch { case use: URISyntaxException => Validated.invalidNel(s"Invalid URI: $s (${ use.getReason })") }
     }
 
-  implicit val readURL: Argument[URL] =
-    Argument.instance { s =>
-      try { Validated.valid(new URL(s)) }
-      catch { case use: MalformedURLException => Validated.invalidNel(s"Invalid URL: $s (${ use.getMessage })") }
-    }
-
   implicit val readUUID: Argument[UUID] =
     Argument.instance { s =>
       try { Validated.valid(UUID.fromString(s)) }
       catch { case _: IllegalArgumentException => Validated.invalidNel(s"Invalid UUID: $s") }
-    }
-
-  implicit val readNioPath: Argument[Path] =
-    Argument.instance { s =>
-      try { Validated.valid(FileSystems.getDefault.getPath(s)) }
-      catch { case _: InvalidPathException => Validated.invalidNel(s"Invalid path: $s") }
     }
 }

--- a/core/shared/src/main/scala/com/monovore/decline/Argument.scala
+++ b/core/shared/src/main/scala/com/monovore/decline/Argument.scala
@@ -1,8 +1,10 @@
 package com.monovore.decline
 
-import java.net.{URI, URISyntaxException}
-
 import cats.data.{Validated, ValidatedNel}
+import java.net.{URI, URISyntaxException, URL, MalformedURLException}
+import java.nio.file.{FileSystems, InvalidPathException, Path}
+import java.util.UUID
+import scala.concurrent.duration.Duration
 
 trait Argument[A] { self =>
   def read(string: String): ValidatedNel[String, A]
@@ -12,28 +14,75 @@ object Argument extends PlatformArguments {
 
   def apply[A](implicit argument: Argument[A]) = argument
 
-  implicit val readString: Argument[String] = new Argument[String] {
+  def instance[A](f: String => ValidatedNel[String, A]): Argument[A] =
+    new Argument[A] {
+      def read(s: String): ValidatedNel[String, A] = f(s)
+    }
 
-    override def read(string: String): ValidatedNel[String, String] = Validated.valid(string)
-  }
+  implicit val readString: Argument[String] =
+    instance(s => Validated.valid(s))
 
-  private def readNum[A](typeName: String)(parse: String => A): Argument[A] = new Argument[A] {
-    override def read(string: String): ValidatedNel[String, A] =
-      try Validated.valid(parse(string))
-      catch { case nfe: NumberFormatException => Validated.invalidNel(s"Invalid $typeName: $string") }
-  }
+  private def readNum[A](typeName: String)(parse: String => A): Argument[A] =
+    instance { s =>
+      try Validated.valid(parse(s))
+      catch { case nfe: NumberFormatException => Validated.invalidNel(s"Invalid $typeName: $s") }
+    }
 
+  implicit val readBoolean: Argument[Boolean] =
+    instance { s =>
+      s.toLowerCase match {
+        case "true" | "t" | "yes" | "y" => Validated.valid(true)
+        case "false" | "f" | "no" | "n" => Validated.valid(false)
+        case _ => Validated.invalidNel(s"Invalid boolean: $s")
+      }
+    }
+
+  implicit val readChar: Argument[Char] =
+    instance { s =>
+      if (s.length == 1) Validated.valid(s.charAt(0))
+      else Validated.invalidNel(s"invalid character: '$s'")
+    }
+
+  implicit val readByte: Argument[Byte] = readNum("integer")(_.toByte)
+  implicit val readShort: Argument[Short] = readNum("integer")(_.toShort)
   implicit val readInt: Argument[Int] = readNum("integer")(_.toInt)
   implicit val readLong: Argument[Long] = readNum("integer")(_.toLong)
   implicit val readBigInt: Argument[BigInt] = readNum("integer")(BigInt(_))
+  implicit val readBigInteger: Argument[java.math.BigInteger] = readNum("integer")(new java.math.BigInteger(_))
+
   implicit val readFloat: Argument[Float] = readNum("floating-point")(_.toFloat)
   implicit val readDouble: Argument[Double] = readNum("floating-point")(_.toDouble)
+
   implicit val readBigDecimal: Argument[BigDecimal] = readNum("decimal")(BigDecimal(_))
+  implicit val readJavaBigDecimal: Argument[java.math.BigDecimal] = readNum("decimal")(new java.math.BigDecimal(_))
 
-  implicit val readURI: Argument[URI] = new Argument[URI] {
+  implicit val readDuration: Argument[Duration] =
+    Argument.instance { s =>
+      try { Validated.valid(Duration(s)) }
+      catch { case _: NumberFormatException => Validated.invalidNel(s"Invalid Duration: $s") }
+    }
 
-    override def read(string: String): ValidatedNel[String, URI] =
-      try { Validated.valid(new URI(string)) }
-      catch { case use: URISyntaxException => Validated.invalidNel(s"Invalid URI: $string (${ use.getReason })") }
-  }
+  implicit val readURI: Argument[URI] =
+    Argument.instance { s =>
+      try { Validated.valid(new URI(s)) }
+      catch { case use: URISyntaxException => Validated.invalidNel(s"Invalid URI: $s (${ use.getReason })") }
+    }
+
+  implicit val readURL: Argument[URL] =
+    Argument.instance { s =>
+      try { Validated.valid(new URL(s)) }
+      catch { case use: MalformedURLException => Validated.invalidNel(s"Invalid URL: $s (${ use.getMessage })") }
+    }
+
+  implicit val readUUID: Argument[UUID] =
+    Argument.instance { s =>
+      try { Validated.valid(UUID.fromString(s)) }
+      catch { case _: IllegalArgumentException => Validated.invalidNel(s"Invalid UUID: $s") }
+    }
+
+  implicit val readNioPath: Argument[Path] =
+    Argument.instance { s =>
+      try { Validated.valid(FileSystems.getDefault.getPath(s)) }
+      catch { case _: InvalidPathException => Validated.invalidNel(s"Invalid path: $s") }
+    }
 }

--- a/core/shared/src/main/scala/com/monovore/decline/Metavar.scala
+++ b/core/shared/src/main/scala/com/monovore/decline/Metavar.scala
@@ -1,0 +1,59 @@
+package com.monovore.decline
+
+import scala.concurrent.duration.Duration
+import scala.reflect.ClassTag
+
+trait Metavar[A] {
+  def name: String
+}
+
+object Metavar extends LowPriorityMetavar {
+  def apply[A](implicit m: Metavar[A]) = m
+
+  def instance[A](name0: String): Metavar[A] =
+    new Metavar[A] {
+      val name: String = name0
+    }
+
+  implicit val unitMetavar = Metavar.instance[Unit]("unit")
+  implicit val booleanMetavar = Metavar.instance[Boolean]("boolean")
+
+  implicit val byteMetavar = Metavar.instance[Byte]("integer")
+  implicit val shortMetavar = Metavar.instance[Short]("integer")
+  implicit val intMetavar = Metavar.instance[Int]("integer")
+  implicit val longMetavar = Metavar.instance[Long]("integer")
+  implicit val bigIntMetavar = Metavar.instance[BigInt]("integer")
+  implicit val bigIntegerMetavar = Metavar.instance[java.math.BigInteger]("integer")
+
+  implicit val floatMetavar = Metavar.instance[Float]("floating-point")
+  implicit val doubleMetavar = Metavar.instance[Double]("floating-point")
+
+  implicit val stringMetavar = Metavar.instance[String]("string")
+
+  implicit val bigDecimalMetavar = Metavar.instance[BigDecimal]("decimal")
+  implicit val javaBigDecimalMetavar = Metavar.instance[java.math.BigDecimal]("decimal")
+
+  implicit val durationMetavar = Metavar.instance[Duration]("duration")
+
+  // most of these are equivalent to using runtimeMetavar but it's
+  // nice to include them in case we do want to change them.
+  implicit val uriMetavar = Metavar.instance[java.net.URI]("uri")
+  implicit val urlMetavar = Metavar.instance[java.net.URL]("url")
+  implicit val currencydMetavar = Metavar.instance[java.util.Currency]("currency")
+  implicit val dateMetavar = Metavar.instance[java.util.Date]("date")
+  implicit val localeMetavar = Metavar.instance[java.util.Locale]("locale")
+  implicit val timeZoneMetavar = Metavar.instance[java.util.TimeZone]("timezone")
+  implicit val uuidMetavar = Metavar.instance[java.util.UUID]("uuid")
+  implicit val pathMetavar = Metavar.instance[java.nio.file.Path]("path")
+}
+
+abstract class LowPriorityMetavar {
+
+  val Basename = """(?:.+\.)([^.]+)$""".r
+
+  implicit def runtimeMetavar[A](implicit ct: ClassTag[A]): Metavar[A] =
+    Metavar.instance(ct.runtimeClass.getName match {
+      case Basename(basename) => basename.toLowerCase
+      case otherwise => otherwise
+    })
+}

--- a/core/shared/src/main/scala/com/monovore/decline/Metavar.scala
+++ b/core/shared/src/main/scala/com/monovore/decline/Metavar.scala
@@ -15,8 +15,8 @@ object Metavar extends LowPriorityMetavar {
       val name: String = name0
     }
 
-  implicit val unitMetavar = Metavar.instance[Unit]("unit")
   implicit val booleanMetavar = Metavar.instance[Boolean]("boolean")
+  implicit val charMetavar = Metavar.instance[Char]("char")
 
   implicit val byteMetavar = Metavar.instance[Byte]("integer")
   implicit val shortMetavar = Metavar.instance[Short]("integer")
@@ -36,13 +36,9 @@ object Metavar extends LowPriorityMetavar {
   implicit val durationMetavar = Metavar.instance[Duration]("duration")
 
   // most of these are equivalent to using runtimeMetavar but it's
-  // nice to include them in case we do want to change them.
+  // nice to include them here in case we do want to change them.
   implicit val uriMetavar = Metavar.instance[java.net.URI]("uri")
   implicit val urlMetavar = Metavar.instance[java.net.URL]("url")
-  implicit val currencydMetavar = Metavar.instance[java.util.Currency]("currency")
-  implicit val dateMetavar = Metavar.instance[java.util.Date]("date")
-  implicit val localeMetavar = Metavar.instance[java.util.Locale]("locale")
-  implicit val timeZoneMetavar = Metavar.instance[java.util.TimeZone]("timezone")
   implicit val uuidMetavar = Metavar.instance[java.util.UUID]("uuid")
   implicit val pathMetavar = Metavar.instance[java.nio.file.Path]("path")
 }

--- a/core/shared/src/main/scala/com/monovore/decline/Metavar.scala
+++ b/core/shared/src/main/scala/com/monovore/decline/Metavar.scala
@@ -7,7 +7,7 @@ trait Metavar[A] {
   def name: String
 }
 
-object Metavar extends LowPriorityMetavar {
+object Metavar extends PlatformMetavars with LowPriorityMetavar {
   def apply[A](implicit m: Metavar[A]) = m
 
   def instance[A](name0: String): Metavar[A] =
@@ -40,10 +40,9 @@ object Metavar extends LowPriorityMetavar {
   implicit val uriMetavar = Metavar.instance[java.net.URI]("uri")
   implicit val urlMetavar = Metavar.instance[java.net.URL]("url")
   implicit val uuidMetavar = Metavar.instance[java.util.UUID]("uuid")
-  implicit val pathMetavar = Metavar.instance[java.nio.file.Path]("path")
 }
 
-abstract class LowPriorityMetavar {
+private[decline] trait LowPriorityMetavar {
 
   val Basename = """(?:.+\.)([^.]+)$""".r
 

--- a/core/shared/src/main/scala/com/monovore/decline/opts.scala
+++ b/core/shared/src/main/scala/com/monovore/decline/opts.scala
@@ -98,8 +98,8 @@ object Opts {
       override def combineK[A](x: Opts[A], y: Opts[A]): Opts[A] = Opts.OrElse(x, y)
     }
 
-  private[this] def metavarFor[A](provided: String)(implicit arg: Argument[A]) =
-    if (provided.isEmpty) arg.defaultMetavar else provided
+  private[this] def metavarFor[A](provided: String)(implicit m: Metavar[A]) =
+    if (provided.isEmpty) m.name else provided
 
   def unit: Opts[Unit] = Pure(())
 
@@ -107,7 +107,7 @@ object Opts {
 
   val never: Opts[Nothing] = Opts.Missing
 
-  def option[A : Argument](
+  def option[A : Argument : Metavar](
     long: String,
     help: String,
     short: String = "",
@@ -117,7 +117,7 @@ object Opts {
     Single(Opt.Regular(namesFor(long, short), metavarFor[A](metavar), help, visibility))
       .mapValidated(Argument[A].read)
 
-  def options[A : Argument](
+  def options[A : Argument : Metavar](
     long: String,
     help: String,
     short: String = "",
@@ -143,11 +143,11 @@ object Opts {
   ): Opts[Int] =
     Repeated(Opt.Flag(namesFor(long, short), help, visibility)).map { _.toList.size }
 
-  def argument[A : Argument](metavar: String = ""): Opts[A] =
+  def argument[A : Argument : Metavar](metavar: String = ""): Opts[A] =
     Single(Opt.Argument(metavarFor[A](metavar)))
       .mapValidated(Argument[A].read)
 
-  def arguments[A : Argument](metavar: String = ""): Opts[NonEmptyList[A]] =
+  def arguments[A : Argument : Metavar](metavar: String = ""): Opts[NonEmptyList[A]] =
     Repeated(Opt.Argument(metavarFor[A](metavar)))
       .mapValidated { args => args.traverse[ValidatedNel[String, ?], A](Argument[A].read) }
 

--- a/core/shared/src/test/scala/com/monovore/decline/ArgumentSpec.scala
+++ b/core/shared/src/test/scala/com/monovore/decline/ArgumentSpec.scala
@@ -5,7 +5,7 @@ import java.nio.file.{Path, Paths}
 import cats.data.Validated._
 import org.scalacheck.Gen
 import org.scalatest.prop.GeneratorDrivenPropertyChecks
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.{Matchers, PropSpec, WordSpec}
 
 class ArgumentSpec extends WordSpec with Matchers with GeneratorDrivenPropertyChecks {
 

--- a/core/shared/src/test/scala/com/monovore/decline/MetavarSpec.scala
+++ b/core/shared/src/test/scala/com/monovore/decline/MetavarSpec.scala
@@ -1,0 +1,36 @@
+package com.monovore.decline
+
+import org.scalatest.{Matchers, WordSpec}
+
+class Foo(x: Int)
+
+class Bar(x: Int)
+
+object Bar {
+  implicit val barMetavar = Metavar.instance[Bar]("barrr")
+}
+
+class MetavarSpec extends WordSpec with Matchers {
+
+  "Metavar" should {
+    "use 'integer' for integer types" in {
+      Metavar[Int].name shouldBe "integer"
+      Metavar[Long].name shouldBe "integer"
+      Metavar[BigInt].name shouldBe "integer"
+    }
+
+    "generate a reasonable Metavar[Foo]" in {
+      Metavar[Foo].name shouldBe "foo"
+    }
+
+    "prefer local instances" in {
+      implicit val m = Metavar.instance[Foo]("foooo")
+      Metavar[Foo].name shouldBe "foooo"
+    }
+
+    "prefer instances from the companion" in {
+      Metavar[Bar].name shouldBe "barrr"
+    }
+  }
+  
+}

--- a/core/shared/src/test/scala/com/monovore/decline/ParseSpec.scala
+++ b/core/shared/src/test/scala/com/monovore/decline/ParseSpec.scala
@@ -130,13 +130,13 @@ class ParseSpec extends WordSpec with Matchers with Checkers {
     }
 
     "work as expected with numeric options" in {
-      def opt[A: Argument]: Opts[A] = Opts.option[A]("num", help = "some number")
-      def good[A: Argument](a: A) = {
+      def opt[A: Argument: Metavar]: Opts[A] = Opts.option[A]("num", help = "some number")
+      def good[A: Argument: Metavar](a: A) = {
         val str = a.toString
         val Valid(result) = opt[A].parse(List("--num", str))
         result should equal(a)
       }
-      def bad[A: Argument](str: String) = {
+      def bad[A: Argument: Metavar](str: String) = {
         val aopt = opt[A]
         aopt.parse(List("--num", str)) match {
           case Valid(s) => fail(s"expected to fail to parse $str, got $s")

--- a/refined/src/main/scala/com/monovore/decline/refined/package.scala
+++ b/refined/src/main/scala/com/monovore/decline/refined/package.scala
@@ -11,8 +11,6 @@ package object refined {
       validate: Validate[T, P]
   ): Argument[F[T, P]] = new Argument[F[T, P]] {
 
-    override def defaultMetavar: String = argument.defaultMetavar
-
     override def read(string: String): ValidatedNel[String, F[T, P]] =
       argument.read(string) match {
         case Validated.Valid(t) =>


### PR DESCRIPTION
This change removes the "defaultMetvar" field from Argument[A], and
adds a new Metavar[A] type class to provide the same functionality.
The API impact of this is minimal: there is an extra type class
instance required when constructing opts, but a low-priority default
Metavar implementation ensures that this is unlikely to be a huge
burden.

The current Metavar implementations were created to match the existing
behavior (e.g. using "integer" for all integer types). I added a bunch
of extra implementations that users might be interested in, but we can
remove those if it seems too noisy.