### PR TITLE
[fixes #40] I've added a test that shows the issue and I've fixed the dupl…

### DIFF
--- a/core/shared/src/main/scala/com/monovore/decline/Help.scala
+++ b/core/shared/src/main/scala/com/monovore/decline/Help.scala
@@ -50,7 +50,7 @@ object Help {
     }
 
     val envVarHelp = {
-      val envVarHelpLines = environmentVarHelpLines(parser.options)
+      val envVarHelpLines = environmentVarHelpLines(parser.options).distinct
       if (envVarHelpLines.isEmpty) Nil
       else ("Environment Variables:" :: envVarHelpLines.map("    " ++ _)).mkString("\n") :: Nil
     }

--- a/core/shared/src/test/scala/com/monovore/decline/HelpSpec.scala
+++ b/core/shared/src/test/scala/com/monovore/decline/HelpSpec.scala
@@ -1,6 +1,6 @@
 package com.monovore.decline
 
-import cats.{Alternative, MonoidK}
+import cats.MonoidK
 import cats.implicits._
 import org.scalatest.{Matchers, WordSpec}
 
@@ -72,6 +72,18 @@ class HelpSpec extends WordSpec with Matchers {
       "right-distribute" in {
         help(((foo <+> bar), baz).tupled) should equal(help((foo, baz).tupled <+> (bar, baz).tupled))
       }
+    }
+
+    "de-duplicate environment variable arguments" in {
+
+      def help[A](opts: Opts[A]): String = {
+        val command = Command("test-command", "...")(opts)
+        Help.fromCommand(command).toString
+      }
+
+      val foo = Opts.env[String]("foo", "only one")
+
+      help(foo) shouldBe help((foo, foo).tupled)
     }
   }
 }


### PR DESCRIPTION
…ication in the environment variables by calling `.distinct` on the lines generated by the help parser.