### PR TITLE
Update docs

### DIFF
--- a/doc/src/main/tut/arguments.md
+++ b/doc/src/main/tut/arguments.md
@@ -78,6 +78,34 @@ implicit val configArgument: Argument[Config] = new Argument[Config] {
 val config = Opts.option[Config]("config", "Specify an additional config.")
 ```
 
+## Custom time-based arguments
+
+As mentioned in the Usage page, `decline` has out-of-the-box support for Java 8 time library by importing the contents
+of the `com.monovore.decline.time` package. But this usage is limited to the standard ISO 8601 formats and some people
+would like to have a more human-friendly format. Fortunately we provide with utility functions that you can use to
+declare your custom arguments just passing a `java.time.format.DateTimeFormatter`.
+
+The following are the recommended imports to take the most of this feature:
+
+```tut:silent
+import java.time._
+import java.time.format.DateTimeFormatter
+import com.monovore.decline.{time => timeargs}
+```
+
+With the previous we can now move on to define the argument parsers:
+
+_**NOTE:** The renaming of the `time` package to `timeargs` is not really necessary but it is recommended just to remove
+ambiguities and potential name collisions._
+
+```tut:book
+implicit val myDateArg: Argument[LocalDate] = timeargs.localDateWithFormatter(
+  DateTimeFormatter.ofPattern("dd/MM/yy")
+)
+
+``` 
+
+That should be enough to have a local date argument using a custom date-time pattern in your program.
 
 ## Missing Instances
 

--- a/doc/src/main/tut/index.md
+++ b/doc/src/main/tut/index.md
@@ -29,7 +29,7 @@ First, pull the library into your build. For `sbt`:
 ```scala
 // `decline` is available for both Scala 2.11 and 2.12
 // 0.5.0 depends only on the`cats` 1.X series
-libraryDependencies += "com.monovore" %% "decline" % "0.5.0"
+libraryDependencies += "com.monovore" %% "decline" % "0.6.0"
 ```
 
 Then, write a program:

--- a/doc/src/main/tut/usage.md
+++ b/doc/src/main/tut/usage.md
@@ -63,6 +63,29 @@ You can also read a value directly from an environment variable.
 val port = Opts.env[Int]("PORT", help = "The port to run on.")
 ```
 
+## Time-based options
+
+There is built-in support for Java 8 based datetime types like `Duration`, `ZonedDateTime`, `ZoneId`, etc in the
+`com.monovore.decline.time` package which you need to import specifically to have access to:
+
+```tut:silent
+import java.time._
+import com.monovore.decline.time._
+```
+
+And now you can use the Java 8 types as previously stated with any other supported type:
+
+```tut:book
+val fromDate = Opts.option[LocalDate]("fromDate", help = "Local date from where start looking at data")
+val timeout = Opts.option[Duration]("timeout", help = "Operation timeout")
+```
+
+The out-of-box support is based on the ISO 8601 formats. If you would like to use these types in your command line
+but with different formats/patterns, then check in the [arguments documentation](./arguments) for more information on how to do it.
+
+_**NOTE**: Java 8 types are seamlessly supported in the JVM and in ScalaJS, the latter is achieved by making the ScalaJS module
+for `decline` have a dependency in [`scala-java-time`](http://cquiroz.github.io/scala-java-time/)._
+
 ## Default Values
 
 All of the above options are _required_: if they're missing, the parser will complain.

--- a/doc/src/main/tut/usage.md
+++ b/doc/src/main/tut/usage.md
@@ -73,7 +73,7 @@ import java.time._
 import com.monovore.decline.time._
 ```
 
-And now you can use the Java 8 types as previously stated with any other supported type:
+And now you can use the Java 8 types as previously stated as with any other supported type:
 
 ```tut:book
 val fromDate = Opts.option[LocalDate]("fromDate", help = "Local date from where start looking at data")


### PR DESCRIPTION
So this is my attempt at updating the docs.

I added two new sections, one in **Usage** for showing the most basic usage relying in the ISO 8601 format. The other section is in `Arguments` for showing how to customize a date format.

Let me know what you think.