### PR TITLE
Fix a flaky test!

### DIFF
--- a/core/shared/src/test/scala/com/monovore/decline/time/JavaTimeSuite.scala
+++ b/core/shared/src/test/scala/com/monovore/decline/time/JavaTimeSuite.scala
@@ -36,7 +36,8 @@ class JavaTimeSuite extends ArgumentSuite with JavaTimeInstances {
   implicit val arbitraryZonedDateTime: Arbitrary[ZonedDateTime] = Arbitrary {
     for {
       instant <- arbitrary[Instant]
-      zoneId  <- arbitrary[ZoneId]
+      // "Text '-140469387-08-22T15:34:00Z[GMT0]' could not be parsed, unparsed text found at index 26"
+      zoneId  <- arbitrary[ZoneId].filter(_ != ZoneId.of("GMT0"))
     } yield instant.atZone(zoneId)
   }
 


### PR DESCRIPTION
It seems like we can generate timezones that we can't parse! Did an exhaustive test... this seems to be the only one that causes trouble.