### PR TITLE
pass default values to `withDefault` by name

### DIFF
--- a/core/shared/src/main/scala/com/monovore/decline/opts.scala
+++ b/core/shared/src/main/scala/com/monovore/decline/opts.scala
@@ -51,7 +51,7 @@ sealed trait Opts[+A] {
 
   def orElse[A0 >: A](other: Opts[A0]): Opts[A0] = Opts.OrElse(this, other)
 
-  def withDefault[A0 >: A](default: A0): Opts[A0] =
+  def withDefault[A0 >: A](default: => A0): Opts[A0] =
     this orElse Opts.apply(default)
 
   def orNone: Opts[Option[A]] =

--- a/core/shared/src/test/scala/com/monovore/decline/ParseSpec.scala
+++ b/core/shared/src/test/scala/com/monovore/decline/ParseSpec.scala
@@ -330,6 +330,16 @@ class ParseSpec extends WordSpec with Matchers with Checkers {
       }
     }
 
+    "lazily evaluate defaults" in {
+      var count = 0
+      val a = Opts.option[Int]("num", "a number").withDefault {
+        count += 1
+        count
+      }
+
+      count should be (0)
+    }
+
     "read from the environment" when {
       "the variable is present" should {
         "read the variable" in {


### PR DESCRIPTION
Until parsing happens within the context of an effect, it would be nice if my default values can be evaluated lazily.