### PR TITLE
added a convenient method for grouping multiple commands into subcommands 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,3 @@
-dist: trusty
-
 language: scala
 
 scala:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
+dist: trusty
+
 language: scala
+
 scala:
   - 2.11.12
   - 2.12.8

--- a/core/shared/src/main/scala/com/monovore/decline/opts.scala
+++ b/core/shared/src/main/scala/com/monovore/decline/opts.scala
@@ -159,6 +159,9 @@ object Opts {
 
   def subcommand[A](command: Command[A]): Opts[A] = Subcommand(command)
 
+  def subcommands[A](head: Command[A], tail: Command[A]* ): Opts[A] =
+    NonEmptyList.of(head, tail:_*).map(subcommand(_)).reduce
+
   def subcommand[A](name: String, help: String, helpFlag: Boolean = true)(opts: Opts[A]): Opts[A] = {
     Subcommand(Command(name, help, helpFlag)(opts))
   }

--- a/core/shared/src/test/scala/com/monovore/decline/ParseSpec.scala
+++ b/core/shared/src/test/scala/com/monovore/decline/ParseSpec.scala
@@ -254,6 +254,20 @@ class ParseSpec extends WordSpec with Matchers with Checkers {
       opts.parse(List("clear", "--bar", "16")) should equal(Valid(Some(16)))
     }
 
+    "handle subcommands passed in convenient method" in {
+      val run = Command("run", "Run the thing!")(
+        Opts.option[Int]("foo", help = "Do the thing!").orNone
+      )
+      val clear = Command("clear", "Clear the thing!")(
+        Opts.option[Int]("bar", help = "Do the thing!").orNone
+      )
+
+      val opts = Opts.subcommands(run, clear)
+
+      opts.parse(List("run", "--foo", "77")) should equal(Valid(Some(77)))
+      opts.parse(List("clear", "--bar", "16")) should equal(Valid(Some(16)))
+    }
+
     "passes trailing options to subcommands" in {
 
       val opt = Opts.option[Int]("flag", "...").orNone


### PR DESCRIPTION
I just found it more natural to create a bunch `Command` and then decide how to organize them later using subcommands. Current this involves in writing `Opts.subcommand(cmd1) orElse Opts.subcommand(cmd2) orElse ...`. In real world, you would probably always have more than one subcommand (hence the need for subcommand), this current API is a bit verbose and not very easy to be discovered. 