### PR TITLE
Mention `tupled` for combining Opts

### DIFF
--- a/doc/src/main/tut/usage.md
+++ b/doc/src/main/tut/usage.md
@@ -144,6 +144,15 @@ val tailOptions = (linesOrDefault, fileList).mapN { (n, files) =>
 }
 ```
 
+[`tupled`](https://github.com/typelevel/cats/blob/69356ef/project/Boilerplate.scala#L136) is a useful operation when you want
+to compose into a larger `Opts` that yields a tuple:
+
+```tut:book
+import cats.implicits._
+
+val tailOptionsTuple = (linesOrDefault, fileList).tupled
+```
+
 Other options are mutually exclusive:
 you might want to pass `--verbose` to make a command noisier,
 or `--quiet` to make it quieter,


### PR DESCRIPTION
When I was learning Decline, this was a key question not covered by the existing docs that I spent a fair bit of time figuring out; want to ease the way for the next person trying out Decline