### PR TITLE
Proposal: Enumeratum Support

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -151,7 +151,7 @@ lazy val enumeratumJS = enumeratum.js
 
 lazy val doc =
   project.in(file("doc"))
-    .dependsOn(declineJVM, refinedJVM, effectJVM)
+    .dependsOn(declineJVM, refinedJVM, effectJVM, enumeratumJVM)
     .enablePlugins(MicrositesPlugin)
     .settings(defaultSettings)
     .settings(noPublishSettings)

--- a/build.sbt
+++ b/build.sbt
@@ -69,7 +69,7 @@ val catsVersion = "2.0.0-M4"
 
 lazy val root =
   project.in(file("."))
-    .aggregate(declineJS, declineJVM, refinedJS, refinedJVM, effectJS, effectJVM, doc)
+    .aggregate(declineJS, declineJVM, refinedJS, refinedJVM, effectJS, effectJVM, enumeratumJS, enumeratumJVM, doc)
     .settings(defaultSettings)
     .settings(noPublishSettings)
 
@@ -135,6 +135,19 @@ lazy val effect =
 
 lazy val effectJVM = effect.jvm
 lazy val effectJS = effect.js
+
+lazy val enumeratum =
+  crossProject(JSPlatform, JVMPlatform).crossType(CrossType.Pure).in(file("enumeratum"))
+    .settings(defaultSettings)
+    .settings(
+      name := "enumeratum",
+      moduleName := "decline-enumeratum",
+      libraryDependencies += "com.beachape" %%% "enumeratum" % "1.5.13"
+    )
+    .dependsOn(decline % "compile->compile;test->test")
+
+lazy val enumeratumJVM = enumeratum.jvm
+lazy val enumeratumJS = enumeratum.js
 
 lazy val doc =
   project.in(file("doc"))

--- a/core/shared/src/main/scala/com/monovore/decline/Argument.scala
+++ b/core/shared/src/main/scala/com/monovore/decline/Argument.scala
@@ -49,6 +49,7 @@ object Argument extends PlatformArguments {
 
   implicit val readInt: Argument[Int] = readNum("integer")(_.toInt)
   implicit val readLong: Argument[Long] = readNum("integer")(_.toLong)
+  implicit val readShort: Argument[Short] = readNum("integer")(_.toShort)
   implicit val readBigInt: Argument[BigInt] = readNum("integer")(BigInt(_))
   implicit val readFloat: Argument[Float] = readNum("floating-point")(_.toFloat)
   implicit val readDouble: Argument[Double] = readNum("floating-point")(_.toDouble)

--- a/core/shared/src/main/scala/com/monovore/decline/Argument.scala
+++ b/core/shared/src/main/scala/com/monovore/decline/Argument.scala
@@ -54,6 +54,16 @@ object Argument extends PlatformArguments {
   implicit val readFloat: Argument[Float] = readNum("floating-point")(_.toFloat)
   implicit val readDouble: Argument[Double] = readNum("floating-point")(_.toDouble)
   implicit val readBigDecimal: Argument[BigDecimal] = readNum("decimal")(BigDecimal(_))
+  implicit val readByte: Argument[Byte] = readNum("byte")(_.toByte)
+
+  implicit val readChar: Argument[Char] = new Argument[Char] {
+    override def defaultMetavar: String = "char"
+
+    override def read(string: String): ValidatedNel[String, Char] = {
+      if (string.size == 1) Validated.validNel(string(0))
+      else Validated.invalidNel(s"Invalid character: $string")
+    }
+  }
 
   implicit val readURI: Argument[URI] = new Argument[URI] {
 

--- a/core/shared/src/test/scala/com/monovore/decline/ArgumentSpec.scala
+++ b/core/shared/src/test/scala/com/monovore/decline/ArgumentSpec.scala
@@ -9,6 +9,7 @@ class ArgumentSpec extends ArgumentSuite {
   checkArgument[String]("String")
   checkArgument[Int]("Int")
   checkArgument[Long]("Long")
+  checkArgument[Short]("Short")
   checkArgument[BigInt]("BigInt")
   checkArgument[UUID]("UUID")
 

--- a/doc/src/main/tut/enumeratum.md
+++ b/doc/src/main/tut/enumeratum.md
@@ -1,0 +1,123 @@
+---
+layout: docs
+title:  "Enumeratum Support"
+position: 3
+---
+
+# Enumeratum Support
+
+Enums support based on [enumeratum](https://github.com/lloydmeta/enumeratum) is provided via the `decline-enumeratum` module.
+Enumeratum provides a powerful Scala-idiomatic and Java-friendly implementation of enums.
+
+This module allows to use the names (or values) associated with the different cases of an enum as an option argument in the command line.
+
+## Defining enumerated values
+
+To make use of the enumeratum features add the following to your `build.sbt`:
+
+```scala
+libraryDependencies += "com.monovore" %% "decline-enumeratum" % "0.7.0"
+```
+
+And now we need to add a series of imports into our current scope:
+
+```tut:silent
+import enumeratum._
+
+import com.monovore.decline.{Opts, Command}
+import com.monovore.decline.enumeratum._
+```
+
+Following there is a very simple example of a plain enum being used as a command line option. First of all,
+we define the given enumeration as per required by `enumeratum`:
+
+```tut:book
+object simple {
+  sealed trait Color extends EnumEntry with EnumEntry.Lowercase
+  object Color extends Enum[Color] {
+    case object Red extends Color
+    case object Green extends Color
+    case object Blue extends Color
+
+    val values = findValues
+  }
+}
+
+import simple._
+```
+
+_Note that the `with EnumEntry.Lowercase` is not really needed, but it will make the different cases available as
+lowercase string values._
+
+And now we define an option parameterised on that enum type and a command so we can test it:
+
+```tut:book
+val color = Opts.option[Color]("color", short = "c", metavar = "color", help = "Choose a color.")
+val cmd = Command("showColor", "Shows the chosen color")(color)
+```
+
+If we now try to parse a command line in which we have a `--color red` argument pair we should be able to parse
+the `color` option:
+
+```tut:book
+cmd.parse(Seq("--color", "red"))
+```
+
+However if we pass a `black` as the argument (a value not part of the enum), the `parse` operation should fail:
+
+```tut:book
+cmd.parse(Seq("--color", "black"))
+```
+
+Note that because we have made the values lowercase (by mixing in the `EnumEntry.Lowercase` trait), if we pass a value
+with the wrong character case, the parsing will fail too:
+
+```tut:book
+cmd.parse(Seq("--color", "Blue"))
+```
+
+## Using value enums
+
+`enumeratum` also supports _value enums_, which are enumerations that are based on a value different than the actual
+enum value name. This support needs a specific import from `enumeratum`:
+
+```tut:silent
+import enumeratum.values._
+```
+
+This is an example of a similar enum as before but being backed by an integer:
+
+```tut:book
+object valued {
+  sealed abstract class IntColor(val value: Int) extends IntEnumEntry
+  object IntColor extends IntEnum[IntColor] {
+    case object Red extends IntColor(0)
+    case object Green extends IntColor(1)
+    case object Blue extends IntColor(2)
+
+    val values = findValues
+  }
+}
+
+import valued._
+```
+
+And now, as before, we define an option parameterised on that enum type and a command so we can test it:
+
+```tut:book
+val intColor = Opts.option[IntColor]("color", short = "c", metavar = "color", help = "Choose a color.")
+val cmd = Command("showColor", "Shows the chosen color")(intColor)
+```
+
+If we now try to parse a command line in which we have a `--color red` argument pair we should be able to parse
+the `color` option:
+
+```tut:book
+cmd.parse(Seq("--color", "0"))
+```
+
+Now, if we instead pass one of the options as text instead of as an `Int`, then the parser will fail:
+
+```tut:book
+cmd.parse(Seq("--color", "red"))
+```

--- a/enumeratum/src/main/scala/com/monovore/decline/enumeratum/ValueEnumArgument.scala
+++ b/enumeratum/src/main/scala/com/monovore/decline/enumeratum/ValueEnumArgument.scala
@@ -5,15 +5,12 @@ import cats.data.{Validated, ValidatedNel}
 
 import _root_.enumeratum.values._
 
-import scala.reflect.ClassTag
-
 private[enumeratum] final class ValueEnumArgument[A, Entry <: ValueEnumEntry[A]](
     enum: ValueEnum[A, Entry],
-    baseArgument: Argument[A],
-    ct: ClassTag[Entry]
+    baseArgument: Argument[A]
   ) extends Argument[Entry] {
   
-  override def defaultMetavar: String = ct.runtimeClass.getSimpleName().toLowerCase()
+  override def defaultMetavar: String = baseArgument.defaultMetavar
 
   override def read(string: String): ValidatedNel[String, Entry] = {
     baseArgument.read(string) match {

--- a/enumeratum/src/main/scala/com/monovore/decline/enumeratum/ValueEnumArgument.scala
+++ b/enumeratum/src/main/scala/com/monovore/decline/enumeratum/ValueEnumArgument.scala
@@ -1,0 +1,28 @@
+package com.monovore.decline
+package enumeratum
+
+import cats.data.{Validated, ValidatedNel}
+
+import _root_.enumeratum.values._
+
+import scala.reflect.ClassTag
+
+private[enumeratum] final class ValueEnumArgument[A, Entry <: ValueEnumEntry[A]](
+    enum: ValueEnum[A, Entry],
+    baseArgument: Argument[A],
+    ct: ClassTag[Entry]
+  ) extends Argument[Entry] {
+  
+  override def defaultMetavar: String = ct.runtimeClass.getSimpleName().toLowerCase()
+
+  override def read(string: String): ValidatedNel[String, Entry] = {
+    baseArgument.read(string) match {
+      case inv @ Validated.Invalid(_) => inv
+      case Validated.Valid(value) =>
+        enum.withValueOpt(value) match {
+          case Some(r) => Validated.validNel(r)
+          case None    => Validated.invalidNel(s"Invalid value: $string")
+        }
+    }
+  }
+}

--- a/enumeratum/src/main/scala/com/monovore/decline/enumeratum/package.scala
+++ b/enumeratum/src/main/scala/com/monovore/decline/enumeratum/package.scala
@@ -5,13 +5,11 @@ import cats.data.{Validated, ValidatedNel}
 import _root_.enumeratum._
 import _root_.enumeratum.values._
 
-import scala.reflect.ClassTag
-
 package object enumeratum {
 
-  implicit def enumeratumEnumEntryArgument[A <: EnumEntry](implicit enum: Enum[A], ct: ClassTag[A]): Argument[A] =
+  implicit def enumeratumEnumEntryArgument[A <: EnumEntry](implicit enum: Enum[A]): Argument[A] =
     new Argument[A] {
-      override def defaultMetavar: String = ct.runtimeClass.getSimpleName().toLowerCase()
+      override def defaultMetavar: String = "value"
 
       override def read(string: String): ValidatedNel[String, A] = {
         enum.withNameOption(string) match {
@@ -21,16 +19,22 @@ package object enumeratum {
       }
     }
 
-  implicit def enumeratumIntEnumEntryArgument[A <: IntEnumEntry](implicit enum: IntEnum[A], ct: ClassTag[A]): Argument[A] =
-    new ValueEnumArgument(enum, Argument[Int], ct)
+  implicit def enumeratumIntEnumEntryArgument[A <: IntEnumEntry](implicit enum: IntEnum[A]): Argument[A] =
+    new ValueEnumArgument(enum, Argument[Int])
 
-  implicit def enumeratumLongEnumEntryArgument[A <: LongEnumEntry](implicit enum: LongEnum[A], ct: ClassTag[A]): Argument[A] =
-    new ValueEnumArgument(enum, Argument[Long], ct)
+  implicit def enumeratumLongEnumEntryArgument[A <: LongEnumEntry](implicit enum: LongEnum[A]): Argument[A] =
+    new ValueEnumArgument(enum, Argument[Long])
 
-  implicit def enumeratumShortEnumEntryArgument[A <: ShortEnumEntry](implicit enum: ShortEnum[A], ct: ClassTag[A]): Argument[A] =
-    new ValueEnumArgument(enum, Argument[Short], ct)
+  implicit def enumeratumShortEnumEntryArgument[A <: ShortEnumEntry](implicit enum: ShortEnum[A]): Argument[A] =
+    new ValueEnumArgument(enum, Argument[Short])
 
-  implicit def enumeratumStringEnumEntryArgument[A <: StringEnumEntry](implicit enum: StringEnum[A], ct: ClassTag[A]): Argument[A] =
-    new ValueEnumArgument(enum, Argument[String], ct)
+  implicit def enumeratumCharEnumEntryArgument[A <: CharEnumEntry](implicit enum: CharEnum[A]): Argument[A] =
+    new ValueEnumArgument(enum, Argument[Char])
+
+  implicit def enumeratumByteEnumEntryArgument[A <: ByteEnumEntry](implicit enum: ByteEnum[A]): Argument[A] =
+    new ValueEnumArgument(enum, Argument[Byte])
+
+  implicit def enumeratumStringEnumEntryArgument[A <: StringEnumEntry](implicit enum: StringEnum[A]): Argument[A] =
+    new ValueEnumArgument(enum, Argument[String])
 
 }

--- a/enumeratum/src/main/scala/com/monovore/decline/enumeratum/package.scala
+++ b/enumeratum/src/main/scala/com/monovore/decline/enumeratum/package.scala
@@ -27,8 +27,8 @@ package object enumeratum {
   implicit def enumeratumLongEnumEntryArgument[A <: LongEnumEntry](implicit enum: LongEnum[A], ct: ClassTag[A]): Argument[A] =
     new ValueEnumArgument(enum, Argument[Long], ct)
 
-  // implicit def enumeratumShortEnumEntryArgument[A <: ShortEnumEntry](implicit enum: ShortEnum[A], ct: ClassTag[A]): Argument[A] =
-  //   new ValueEnumArgument(enum, Argument[Short], ct)
+  implicit def enumeratumShortEnumEntryArgument[A <: ShortEnumEntry](implicit enum: ShortEnum[A], ct: ClassTag[A]): Argument[A] =
+    new ValueEnumArgument(enum, Argument[Short], ct)
 
   implicit def enumeratumStringEnumEntryArgument[A <: StringEnumEntry](implicit enum: StringEnum[A], ct: ClassTag[A]): Argument[A] =
     new ValueEnumArgument(enum, Argument[String], ct)

--- a/enumeratum/src/main/scala/com/monovore/decline/enumeratum/package.scala
+++ b/enumeratum/src/main/scala/com/monovore/decline/enumeratum/package.scala
@@ -1,0 +1,36 @@
+package com.monovore.decline
+
+import cats.data.{Validated, ValidatedNel}
+
+import _root_.enumeratum._
+import _root_.enumeratum.values._
+
+import scala.reflect.ClassTag
+
+package object enumeratum {
+
+  implicit def enumeratumEnumEntryArgument[A <: EnumEntry](implicit enum: Enum[A], ct: ClassTag[A]): Argument[A] =
+    new Argument[A] {
+      override def defaultMetavar: String = ct.runtimeClass.getSimpleName().toLowerCase()
+
+      override def read(string: String): ValidatedNel[String, A] = {
+        enum.withNameOption(string) match {
+          case Some(v) => Validated.validNel(v)
+          case None    => Validated.invalidNel(s"Invalid value: $string")
+        }
+      }
+    }
+
+  implicit def enumeratumIntEnumEntryArgument[A <: IntEnumEntry](implicit enum: IntEnum[A], ct: ClassTag[A]): Argument[A] =
+    new ValueEnumArgument(enum, Argument[Int], ct)
+
+  implicit def enumeratumLongEnumEntryArgument[A <: LongEnumEntry](implicit enum: LongEnum[A], ct: ClassTag[A]): Argument[A] =
+    new ValueEnumArgument(enum, Argument[Long], ct)
+
+  // implicit def enumeratumShortEnumEntryArgument[A <: ShortEnumEntry](implicit enum: ShortEnum[A], ct: ClassTag[A]): Argument[A] =
+  //   new ValueEnumArgument(enum, Argument[Short], ct)
+
+  implicit def enumeratumStringEnumEntryArgument[A <: StringEnumEntry](implicit enum: StringEnum[A], ct: ClassTag[A]): Argument[A] =
+    new ValueEnumArgument(enum, Argument[String], ct)
+
+}

--- a/enumeratum/src/test/scala/com/monovore/decline/enumeratum/EnumeratumArgumentSpec.scala
+++ b/enumeratum/src/test/scala/com/monovore/decline/enumeratum/EnumeratumArgumentSpec.scala
@@ -60,20 +60,20 @@ object Card extends LongEnum[Card] {
   implicit val showCard: Show[Card] = Show.show(_.value.toString())
 }
 
-// sealed abstract class ShortCard(val value: Short) extends ShortEnumEntry
-// object ShortCard extends ShortEnum[ShortCard] {
-//   case object Ace extends ShortCard(1)
-//   case object King extends ShortCard(10)
-//   case object Queen extends ShortCard(9)
+sealed abstract class ShortCard(val value: Short) extends ShortEnumEntry
+object ShortCard extends ShortEnum[ShortCard] {
+  case object Ace extends ShortCard(1)
+  case object King extends ShortCard(10)
+  case object Queen extends ShortCard(9)
 
-//   val values = findValues
+  val values = findValues
 
-//   implicit val arbitraryShortCard: Arbitrary[ShortCard] =
-//     Arbitrary(Gen.oneOf(values))
+  implicit val arbitraryShortCard: Arbitrary[ShortCard] =
+    Arbitrary(Gen.oneOf(values))
 
-//   implicit val eqShortCard: Eq[ShortCard] = Eq.fromUniversalEquals
-//   implicit val showShortCard: Show[ShortCard] = Show.show(_.value.toString())
-// }
+  implicit val eqShortCard: Eq[ShortCard] = Eq.fromUniversalEquals
+  implicit val showShortCard: Show[ShortCard] = Show.show(_.value.toString())
+}
 
 sealed abstract class Option(val value: String) extends StringEnumEntry
 object Option extends StringEnum[Option] {
@@ -92,10 +92,10 @@ object Option extends StringEnum[Option] {
 
 class EnumeratumArgumentSpec extends ArgumentSuite {
 
-  checkArgument[Greeting]("Greeting enum")
-  checkArgument[WeekDay]("WeekDay (int) enum")
-  checkArgument[Card]("Card (long) enum")
-  //checkArgument[ShortCard]("Card (short) enum")
-  checkArgument[Option]("Option (string) enum")
+  checkArgument[Greeting]("Greeting")
+  checkArgument[WeekDay]("WeekDay")
+  checkArgument[Card]("Card")
+  checkArgument[ShortCard]("ShortCard")
+  checkArgument[Option]("Option")
 
 }

--- a/enumeratum/src/test/scala/com/monovore/decline/enumeratum/EnumeratumArgumentSpec.scala
+++ b/enumeratum/src/test/scala/com/monovore/decline/enumeratum/EnumeratumArgumentSpec.scala
@@ -75,6 +75,36 @@ object ShortCard extends ShortEnum[ShortCard] {
   implicit val showShortCard: Show[ShortCard] = Show.show(_.value.toString())
 }
 
+sealed abstract class CharCard(val value: Char) extends CharEnumEntry
+object CharCard extends CharEnum[CharCard] {
+  case object Ace extends CharCard('a')
+  case object King extends CharCard('k')
+  case object Queen extends CharCard('q')
+
+  val values = findValues
+
+  implicit val arbitraryCharCard: Arbitrary[CharCard] =
+    Arbitrary(Gen.oneOf(values))
+
+  implicit val eqCharCard: Eq[CharCard] = Eq.fromUniversalEquals
+  implicit val showCharCard: Show[CharCard] = Show.show(_.value.toString())
+}
+
+sealed abstract class ByteCard(val value: Byte) extends ByteEnumEntry
+object ByteCard extends ByteEnum[ByteCard] {
+  case object Ace extends ByteCard(0)
+  case object King extends ByteCard(1)
+  case object Queen extends ByteCard(2)
+
+  val values = findValues
+
+  implicit val arbitraryByteCard: Arbitrary[ByteCard] =
+    Arbitrary(Gen.oneOf(values))
+
+  implicit val eqByteCard: Eq[ByteCard] = Eq.fromUniversalEquals
+  implicit val showByteCard: Show[ByteCard] = Show.show(_.value.toString())
+}
+
 sealed abstract class Option(val value: String) extends StringEnumEntry
 object Option extends StringEnum[Option] {
   case object A extends Option("option-a")
@@ -96,6 +126,8 @@ class EnumeratumArgumentSpec extends ArgumentSuite {
   checkArgument[WeekDay]("WeekDay")
   checkArgument[Card]("Card")
   checkArgument[ShortCard]("ShortCard")
+  checkArgument[CharCard]("CharCard")
+  checkArgument[ByteCard]("ByteCard")
   checkArgument[Option]("Option")
 
 }

--- a/enumeratum/src/test/scala/com/monovore/decline/enumeratum/EnumeratumArgumentSpec.scala
+++ b/enumeratum/src/test/scala/com/monovore/decline/enumeratum/EnumeratumArgumentSpec.scala
@@ -1,0 +1,101 @@
+package com.monovore.decline.enumeratum
+
+import cats.{Eq, Show}
+
+import enumeratum._
+import enumeratum.EnumEntry._
+import enumeratum.values._
+
+import org.scalatest._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalacheck.{Gen, Arbitrary}
+
+import com.monovore.decline.discipline.ArgumentSuite
+
+sealed trait Greeting extends EnumEntry with Uppercase
+object Greeting extends Enum[Greeting] {
+  case object Hello extends Greeting
+  case object GoodBye extends Greeting with Lowercase
+
+  val values = findValues
+
+  implicit val arbitraryGreeting: Arbitrary[Greeting] =
+    Arbitrary(Gen.oneOf(values))
+
+  implicit val eqGreeting: Eq[Greeting] = Eq.fromUniversalEquals
+  implicit val showGreeting: Show[Greeting] = Show.show(_.entryName)
+}
+
+sealed abstract class WeekDay(val value: Int) extends IntEnumEntry
+object WeekDay extends IntEnum[WeekDay] {
+  case object Monday extends WeekDay(0)
+  case object Tuesday extends WeekDay(1)
+  case object Wednesday extends WeekDay(2)
+  case object Thursday extends WeekDay(3)
+  case object Friday extends WeekDay(4)
+  case object Saturday extends WeekDay(5)
+  case object Sunday extends WeekDay(6)
+
+  val values = findValues
+
+  implicit val arbitraryWeekDay: Arbitrary[WeekDay] =
+    Arbitrary(Gen.oneOf(values))
+
+  implicit val eqWeekDay: Eq[WeekDay] = Eq.fromUniversalEquals
+  implicit val showWeekDay: Show[WeekDay] = Show.show(_.value.toString())
+}
+
+sealed abstract class Card(val value: Long) extends LongEnumEntry
+object Card extends LongEnum[Card] {
+  case object Ace extends Card(1L)
+  case object King extends Card(10L)
+  case object Queen extends Card(9L)
+
+  val values = findValues
+
+  implicit val arbitraryCard: Arbitrary[Card] =
+    Arbitrary(Gen.oneOf(values))
+
+  implicit val eqCard: Eq[Card] = Eq.fromUniversalEquals
+  implicit val showCard: Show[Card] = Show.show(_.value.toString())
+}
+
+// sealed abstract class ShortCard(val value: Short) extends ShortEnumEntry
+// object ShortCard extends ShortEnum[ShortCard] {
+//   case object Ace extends ShortCard(1)
+//   case object King extends ShortCard(10)
+//   case object Queen extends ShortCard(9)
+
+//   val values = findValues
+
+//   implicit val arbitraryShortCard: Arbitrary[ShortCard] =
+//     Arbitrary(Gen.oneOf(values))
+
+//   implicit val eqShortCard: Eq[ShortCard] = Eq.fromUniversalEquals
+//   implicit val showShortCard: Show[ShortCard] = Show.show(_.value.toString())
+// }
+
+sealed abstract class Option(val value: String) extends StringEnumEntry
+object Option extends StringEnum[Option] {
+  case object A extends Option("option-a")
+  case object B extends Option("option-b")
+  case object C extends Option("option-c")
+
+  val values = findValues
+
+  implicit val arbitraryOption: Arbitrary[Option] =
+    Arbitrary(Gen.oneOf(values))
+
+  implicit val eqOption: Eq[Option] = Eq.fromUniversalEquals
+  implicit val showOption: Show[Option] = Show.show(_.value.toString())
+}
+
+class EnumeratumArgumentSpec extends ArgumentSuite {
+
+  checkArgument[Greeting]("Greeting enum")
+  checkArgument[WeekDay]("WeekDay (int) enum")
+  checkArgument[Card]("Card (long) enum")
+  //checkArgument[ShortCard]("Card (short) enum")
+  checkArgument[Option]("Option (string) enum")
+
+}


### PR DESCRIPTION
I find quite useful to be able to define enumerated values in my applications and, until Scala 3 arrives, the best support for enumerated values comes via the `enumeratum` library.

This PR adds another module to decline bringing an integration with that library so the cases for a given enumerated type can be used as command line arguments.

PS: Took the liberty to add an instance for `Argument[Short]` since it looked to me that the fact that it was missing may have been overlooked. Still, there is possibility here to add also instances for `Argument[Char]` and `Argument[Byte]` so enums backed by `Char` or `Byte` can also be used.