### PR TITLE
Parameterize library version in documentation

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,6 @@
 import ReleaseTransformations._
 import sbtcrossproject.{crossProject, CrossType}
+import microsites._
 
 enablePlugins(ScalaJSPlugin)
 
@@ -176,6 +177,11 @@ lazy val doc =
         "gray-light"        -> "#E3E2E3",
         "gray-lighter"      -> "#F4F3F4",
         "white-color"       -> "#fdf6e3"
+      ),
+      micrositeConfigYaml := ConfigYml(
+        yamlCustomProperties = Map(
+          "declineVersion" -> version.value
+        )
       ),
       micrositeCompilingDocsTool := WithMdoc,
       mdocIn := tutSourceDirectory.value,

--- a/doc/src/main/tut/arguments.md
+++ b/doc/src/main/tut/arguments.md
@@ -67,7 +67,7 @@ the introduction of invalid values by the user.
 To make use of `decline-refined`, add the following to your `build.sbt`:
 
 ```scala
-libraryDependencies += "com.monovore" %% "decline-refined" % "0.6.0"
+libraryDependencies += "com.monovore" %% "decline-refined" % "{{site.declineVersion}}"
 ```
 
 As an example, let's define a simple refined type and use it as a command-line argument.
@@ -99,7 +99,7 @@ Enumeratum provides a powerful Scala-idiomatic and Java-friendly implementation 
 To make use of the `enumeratum` support, add the following to your `build.sbt`:
 
 ```scala
-libraryDependencies += "com.monovore" %% "decline-enumeratum" % "0.7.0"
+libraryDependencies += "com.monovore" %% "decline-enumeratum" % "{{site.declineVersion}}"
 ```
 
 As an example,

--- a/doc/src/main/tut/effect.md
+++ b/doc/src/main/tut/effect.md
@@ -27,7 +27,7 @@ We'll focus only on the `ps` and `build` commands -- just enough to get the poin
 First, we'll add the module to our dependencies:
 
 ```scala
-libraryDependencies += "com.monovore" %% "decline-effect" % "0.6.3"
+libraryDependencies += "com.monovore" %% "decline-effect" % "{{site.declineVersion}}"
 ```
 
 And add the necessary imports:

--- a/doc/src/main/tut/index.md
+++ b/doc/src/main/tut/index.md
@@ -27,7 +27,7 @@ and built on [`cats`][cats].
 First, pull the library into your build. For `sbt`:
 
 ```scala
-libraryDependencies += "com.monovore" %% "decline" % "1.0.0"
+libraryDependencies += "com.monovore" %% "decline" % "{{site.declineVersion}}"
 ```
 
 Then, write a program:


### PR DESCRIPTION
First of all, thanks for the shout out on Twitter, really appreciated it.

I was checking the new docs, which are way more accessible than the previus version, and noticed some inconsistencies with the version numbers on the extension modules. Since you have ported them to Mdoc, we can pass values from the `build.sbt` file into the docs to solve that.

So this is a tiny PR just adding that.