### PR TITLE
Substitute cats.effect.IO with polymorphic effect type in CommandIOApp

### DIFF
--- a/doc/src/main/tut/effect.md
+++ b/doc/src/main/tut/effect.md
@@ -109,7 +109,7 @@ Now we'll build an interpreter for the data type we just created.
 This could be done using the `CommandIOApp` as follows:
 
 ```scala mdoc:to-string
-object DockerApp extends CommandIOApp[IO](
+object DockerApp extends CommandIOApp(
   name = "docker",
   header = "Faux docker command line",
   version = "0.0.x"

--- a/doc/src/main/tut/effect.md
+++ b/doc/src/main/tut/effect.md
@@ -109,7 +109,7 @@ Now we'll build an interpreter for the data type we just created.
 This could be done using the `CommandIOApp` as follows:
 
 ```scala mdoc:to-string
-object DockerApp extends CommandIOApp(
+object DockerApp extends CommandIOApp[IO](
   name = "docker",
   header = "Faux docker command line",
   version = "0.0.x"

--- a/effect/jvm/src/test/scala/com/monovore/decline/effect/PureHelloWorld.scala
+++ b/effect/jvm/src/test/scala/com/monovore/decline/effect/PureHelloWorld.scala
@@ -1,6 +1,8 @@
 package com.monovore.decline.effect
 
-import cats.effect.IO
+import cats.implicits._
+import cats.effect.{ExitCode, IO}
+
 import com.monovore.decline._
 
 object PureHelloWorld
@@ -10,10 +12,10 @@ object PureHelloWorld
       version = "0.0.1"
     ) {
 
-  def main: Opts[IO[Unit]] = {
+  def main: Opts[IO[ExitCode]] = {
     val toGreetOpt = Opts.argument[String]("to-greet")
     toGreetOpt.map { toGreet =>
-      IO(println(s"Hello $toGreet"))
+      IO(println(s"Hello $toGreet")).as(ExitCode.Success)
     }
   }
 

--- a/effect/jvm/src/test/scala/com/monovore/decline/effect/PureHelloWorld.scala
+++ b/effect/jvm/src/test/scala/com/monovore/decline/effect/PureHelloWorld.scala
@@ -1,12 +1,12 @@
 package com.monovore.decline.effect
 
-import cats.implicits._
 import cats.effect.{ExitCode, IO}
+import cats.implicits._
 
 import com.monovore.decline._
 
 object PureHelloWorld
-    extends CommandIOApp[IO](
+    extends CommandIOApp(
       name = "pure-hello",
       header = "Pure Hello World with Decline",
       version = "0.0.1"

--- a/effect/jvm/src/test/scala/com/monovore/decline/effect/PureHelloWorld.scala
+++ b/effect/jvm/src/test/scala/com/monovore/decline/effect/PureHelloWorld.scala
@@ -1,21 +1,20 @@
 package com.monovore.decline.effect
 
-import cats.effect.{ExitCode, IO}
-import cats.implicits._
-
+import cats.effect.IO
 import com.monovore.decline._
 
-object PureHelloWorld extends CommandIOApp(
-  name = "pure-hello",
-  header = "Pure Hello World with Decline",
-  version = "0.0.1"
-) {
+object PureHelloWorld
+    extends CommandIOApp[IO](
+      name = "pure-hello",
+      header = "Pure Hello World with Decline",
+      version = "0.0.1"
+    ) {
 
-  def main: Opts[IO[ExitCode]] = {
+  def main: Opts[IO[Unit]] = {
     val toGreetOpt = Opts.argument[String]("to-greet")
     toGreetOpt.map { toGreet =>
-      IO(println(s"Hello $toGreet")).as(ExitCode.Success)
+      IO(println(s"Hello $toGreet"))
     }
   }
-  
+
 }

--- a/effect/shared/src/main/scala/com/monovore/decline/effect/CommandIOApp.scala
+++ b/effect/shared/src/main/scala/com/monovore/decline/effect/CommandIOApp.scala
@@ -1,52 +1,70 @@
 package com.monovore.decline.effect
 
-import cats.effect.implicits._
-import cats.effect.{Effect, ExitCode, IO, IOApp}
+import cats.effect.{ExitCode, IO, IOApp, Sync}
 import cats.implicits._
+
 import com.monovore.decline._
 
 import scala.language.higherKinds
 
-abstract class CommandIOApp[F[_]: Effect](
+abstract class CommandIOApp(
     name: String,
     header: String,
     helpFlag: Boolean = true,
     version: String = ""
 ) extends IOApp {
 
-  def main: Opts[F[ExitCode]]
-
-  private[this] def command: Command[IO[ExitCode]] = {
-    val mainCommand: Opts[IO[ExitCode]] =
-      main.map(_.toIO)
-
-    val showVersion: Opts[IO[ExitCode]] = {
-      if (version.isEmpty) Opts.never
-      else {
-        val flag = Opts.flag(
-          long = "version",
-          short = "v",
-          help = "Print the version number and exit.",
-          visibility = Visibility.Partial
-        )
-        flag.as(IO(System.out.println(version)).as(ExitCode.Success))
-      }
-    }
-
-    Command(name, header, helpFlag)(showVersion orElse mainCommand)
-  }
+  def main: Opts[IO[ExitCode]]
 
   override final def run(args: List[String]): IO[ExitCode] = {
-    def printHelp(help: Help): IO[ExitCode] =
-      IO(System.err.println(help)).as {
-        if (help.errors.nonEmpty) ExitCode.Error
-        else ExitCode.Success
-      }
+    import CommandIOApp._
+
+    val opts = if (version.isEmpty) main else addVersionFlag(main)(version)
+    val command = Command(name, header, helpFlag)(opts)
 
     for {
       parseResult <- IO(command.parse(PlatformApp.ambientArgs getOrElse args, sys.env))
-      exitCode <- parseResult.fold(printHelp, identity)
+      exitCode <- parseResult.fold(printHelp[IO], identity)
     } yield exitCode
+  }
+
+}
+
+object CommandIOApp {
+
+  def run[F[_]](
+      name: String,
+      header: String,
+      helpFlag: Boolean = true,
+      version: Option[String] = None
+  )(opts: Opts[F[ExitCode]], args: List[String])(implicit F: Sync[F]): F[ExitCode] =
+    run(Command(name, header, helpFlag)(version.map(addVersionFlag(opts)).getOrElse(opts)), args)
+
+  def run[F[_]](command: Command[F[ExitCode]], args: List[String])(
+      implicit F: Sync[F]
+  ): F[ExitCode] =
+    for {
+      parseResult <- F.delay(command.parse(PlatformApp.ambientArgs getOrElse args, sys.env))
+      exitCode <- parseResult.fold(printHelp[F], identity)
+    } yield exitCode
+
+  private[CommandIOApp] def printHelp[F[_]: Sync](help: Help): F[ExitCode] =
+    Sync[F].delay(System.err.println(help)).as {
+      if (help.errors.nonEmpty) ExitCode.Error
+      else ExitCode.Success
+    }
+
+  private[CommandIOApp] def addVersionFlag[F[_]: Sync](
+      opts: Opts[F[ExitCode]]
+  )(version: String): Opts[F[ExitCode]] = {
+    val flag = Opts.flag(
+      long = "version",
+      short = "v",
+      help = "Print the version number and exit.",
+      visibility = Visibility.Partial
+    )
+
+    flag.as(Sync[F].delay(System.out.println(version)).as(ExitCode.Success)) orElse opts
   }
 
 }

--- a/effect/shared/src/main/scala/com/monovore/decline/effect/CommandIOApp.scala
+++ b/effect/shared/src/main/scala/com/monovore/decline/effect/CommandIOApp.scala
@@ -16,17 +16,8 @@ abstract class CommandIOApp(
 
   def main: Opts[IO[ExitCode]]
 
-  override final def run(args: List[String]): IO[ExitCode] = {
-    import CommandIOApp._
-
-    val opts = if (version.isEmpty) main else addVersionFlag(main)(version)
-    val command = Command(name, header, helpFlag)(opts)
-
-    for {
-      parseResult <- IO(command.parse(PlatformApp.ambientArgs getOrElse args, sys.env))
-      exitCode <- parseResult.fold(printHelp[IO], identity)
-    } yield exitCode
-  }
+  override final def run(args: List[String]): IO[ExitCode] =
+    CommandIOApp.run[IO](name, header, helpFlag, Option(version).filter(_.nonEmpty))(main, args)
 
 }
 

--- a/effect/shared/src/main/scala/com/monovore/decline/effect/CommandIOApp.scala
+++ b/effect/shared/src/main/scala/com/monovore/decline/effect/CommandIOApp.scala
@@ -14,11 +14,11 @@ abstract class CommandIOApp[F[_]: Effect](
     version: String = ""
 ) extends IOApp {
 
-  def main: Opts[F[_]]
+  def main: Opts[F[ExitCode]]
 
   private[this] def command: Command[IO[ExitCode]] = {
     val mainCommand: Opts[IO[ExitCode]] =
-      main.map(_.toIO.as(ExitCode.Success).handleError(_ => ExitCode.Error))
+      main.map(_.toIO)
 
     val showVersion: Opts[IO[ExitCode]] = {
       if (version.isEmpty) Opts.never

--- a/effect/shared/src/main/scala/com/monovore/decline/effect/CommandIOApp.scala
+++ b/effect/shared/src/main/scala/com/monovore/decline/effect/CommandIOApp.scala
@@ -1,6 +1,5 @@
 package com.monovore.decline.effect
 
-import cats.ApplicativeError
 import cats.effect.implicits._
 import cats.effect.{Effect, ExitCode, IO, IOApp}
 import cats.implicits._
@@ -8,13 +7,12 @@ import com.monovore.decline._
 
 import scala.language.higherKinds
 
-abstract class CommandIOApp[F[_]](
+abstract class CommandIOApp[F[_]: Effect](
     name: String,
     header: String,
     helpFlag: Boolean = true,
     version: String = ""
-)(implicit ev1: Effect[F], ev2: ApplicativeError[F, Throwable])
-    extends IOApp {
+) extends IOApp {
 
   def main: Opts[F[_]]
 


### PR DESCRIPTION
This PR aims to support using ZIO (and even Monix) with CommandIOApp in a straightforward way.

CommandIOApp now accepts an F[_] type parameter with implicit evidence of Effect[F], which is provided out of the box and automatically imported by cats-effect for IO, while for ZIO and Monix it need to be imported from the respective interop packages.

Its main abstract method is now polymorphic in F and can return any Opts[F[_]].
The behavior of CommandIOApp is maintained by mapping the success case to ExitCode.Success, and handling error (via ApplicativeError) by discarding the error informations and returning ExitCode.Error.

See the updated PureHelloWorld for an example.

Resolves #101 