### PR TITLE
Tweak error message

### DIFF
--- a/core/shared/src/main/scala/com/monovore/decline/Result.scala
+++ b/core/shared/src/main/scala/com/monovore/decline/Result.scala
@@ -42,7 +42,7 @@ private[decline] object Result {
         if (envVars.isEmpty) None
         else Some(envVars.distinct.mkString("environment variable (", " or ", ")"))
 
-      s"Missing expected ${List(flagString, commandString, argString, envVarString).flatten.mkString(", or ")}!"
+      s"Missing expected ${List(flagString, commandString, argString, envVarString).flatten.mkString(", or ")}"
     }
   }
 

--- a/core/shared/src/test/scala/com/monovore/decline/ParseSpec.scala
+++ b/core/shared/src/test/scala/com/monovore/decline/ParseSpec.scala
@@ -359,7 +359,7 @@ class ParseSpec extends AnyWordSpec with Matchers with Checkers {
         "complain that the variable is required" in {
           val opts = whatever orElse Opts.env[Int]("WHATEVER", "...")
           val Invalid(errs) = opts.parse(List(), env=Map.empty)
-          errs should equal(List("Missing expected flag --whatever, or environment variable (WHATEVER)!"))
+          errs should equal(List("Missing expected flag --whatever, or environment variable (WHATEVER)"))
         }
       }
 


### PR DESCRIPTION
I know this is really minor so feel free to just close it if you don't like it, but I found the exclamation marks in the error messages kind of distracting, like:

```
Missing expected flag --rating!
```

It's jarring and it almost looks like it's part of the name.

I could just map the errors and strip them off, but I think the better default is to not include anything extra. Plus it's easier to append additional stuff than it is to strip stuff from strings (fewer corner cases to consider).