### PR TITLE
Update discipline-scalatest

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -89,8 +89,8 @@ lazy val decline =
       description := "Composable command-line parsing for Scala",
       libraryDependencies ++= Seq(
         "org.typelevel"  %%% "cats-core"            % catsVersion,
-        "org.typelevel"  %%% "cats-laws"            % catsVersion % "test",
-        "org.typelevel"  %%% "discipline-scalatest" % "1.0.0-M1"  % "test"
+        "org.typelevel"  %%% "cats-laws"            % catsVersion % Test,
+        "org.typelevel"  %%% "discipline-scalatest" % "1.0.0-RC4"  % Test
       ),
     )
     .jvmSettings(

--- a/core/jvm/src/test/scala/com/monovore/decline/PlatformArgumentsSpec.scala
+++ b/core/jvm/src/test/scala/com/monovore/decline/PlatformArgumentsSpec.scala
@@ -4,7 +4,7 @@ import java.nio.file.{Path, Paths}
 
 import cats.data.Validated.Valid
 import org.scalacheck.Gen
-import org.scalatest.Matchers
+import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 

--- a/core/shared/src/test/scala/com/monovore/decline/HelpSpec.scala
+++ b/core/shared/src/test/scala/com/monovore/decline/HelpSpec.scala
@@ -2,7 +2,7 @@ package com.monovore.decline
 
 import cats.MonoidK
 import cats.implicits._
-import org.scalatest.Matchers
+import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
 class HelpSpec extends AnyWordSpec with Matchers {

--- a/core/shared/src/test/scala/com/monovore/decline/ParseSpec.scala
+++ b/core/shared/src/test/scala/com/monovore/decline/ParseSpec.scala
@@ -7,9 +7,9 @@ import cats.implicits._
 import cats.laws.discipline.AlternativeTests
 import org.scalacheck.{Arbitrary, Gen, Prop}
 import org.scalactic.anyvals.PosInt
-import org.scalatestplus.scalacheck.Checkers
-import org.scalatest.Matchers
+import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
+import org.scalatestplus.scalacheck.Checkers
 
 class ParseSpec extends AnyWordSpec with Matchers with Checkers {
 

--- a/core/shared/src/test/scala/com/monovore/decline/UsageSpec.scala
+++ b/core/shared/src/test/scala/com/monovore/decline/UsageSpec.scala
@@ -1,6 +1,6 @@
 package com.monovore.decline
 
-import org.scalatest.Matchers
+import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
 class UsageSpec extends AnyWordSpec with Matchers {

--- a/core/shared/src/test/scala/com/monovore/decline/discipline/ArgumentSuite.scala
+++ b/core/shared/src/test/scala/com/monovore/decline/discipline/ArgumentSuite.scala
@@ -4,8 +4,8 @@ import cats.{instances, syntax, Eq, Show}
 import org.typelevel.discipline.scalatest.FunSuiteDiscipline
 import org.scalacheck.Arbitrary
 import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
 import org.scalatest.prop.Configuration
-import org.scalatest.Matchers
 
 abstract class ArgumentSuite extends AnyFunSuite
   with FunSuiteDiscipline

--- a/core/shared/src/test/scala/com/monovore/decline/discipline/ArgumentSuite.scala
+++ b/core/shared/src/test/scala/com/monovore/decline/discipline/ArgumentSuite.scala
@@ -1,13 +1,15 @@
 package com.monovore.decline.discipline
 
 import cats.{instances, syntax, Eq, Show}
-import org.typelevel.discipline.scalatest.Discipline
+import org.typelevel.discipline.scalatest.FunSuiteDiscipline
 import org.scalacheck.Arbitrary
 import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.prop.Configuration
 import org.scalatest.Matchers
 
 abstract class ArgumentSuite extends AnyFunSuite
-  with Discipline
+  with FunSuiteDiscipline
+  with Configuration
   with Matchers
   with instances.AllInstances
   with syntax.AllSyntax {

--- a/effect/jvm/src/test/scala/com/monovore/decline/effect/CommandIOAppSpec.scala
+++ b/effect/jvm/src/test/scala/com/monovore/decline/effect/CommandIOAppSpec.scala
@@ -2,8 +2,8 @@ package com.monovore.decline.effect
 
 import cats.effect.ExitCode
 
-import org.scalatest.Matchers
 import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 class CommandIOAppSpec extends AnyFlatSpec with Matchers {
 


### PR DESCRIPTION
There's a breaking change in the 1.0.0-RC4 release candidate, and it also transitively pulls in ScalaTest 3.1.0, which has some new deprecations.