### PR TITLE
Add help message customizability

### DIFF
--- a/core/shared/src/main/scala/com/monovore/decline/CommandApp.scala
+++ b/core/shared/src/main/scala/com/monovore/decline/CommandApp.scala
@@ -26,7 +26,7 @@ abstract class CommandApp(command: Command[Unit]) {
       name: String,
       header: String,
       main: Opts[Unit],
-      helpFlag: Boolean = true,
+      helpFlag: Option[Opts[Nothing]] = Some(Opts.help),
       version: String = ""
   ) {
 

--- a/core/shared/src/main/scala/com/monovore/decline/opts.scala
+++ b/core/shared/src/main/scala/com/monovore/decline/opts.scala
@@ -166,7 +166,7 @@ object Opts {
       .mapValidated(args => args.traverse[ValidatedNel[String, ?], A](Argument[A].read))
 
   val help: Opts[Nothing] =
-    flag("help", help = "Display this help text.", visibility = Visibility.Partial).asHelp
+    flag("help", help = "Display this help text.", short = "h", visibility = Visibility.Partial).asHelp
 
   def subcommand[A](command: Command[A]): Opts[A] = Subcommand(command)
 

--- a/core/shared/src/main/scala/com/monovore/decline/opts.scala
+++ b/core/shared/src/main/scala/com/monovore/decline/opts.scala
@@ -28,10 +28,10 @@ class Command[+A] private[decline] (
 }
 
 object Command {
-  def apply[A](name: String, header: String, helpFlag: Boolean = true)(
+  def apply[A](name: String, header: String, helpFlag: Option[Opts[Nothing]] = Some(Opts.help))(
       opts: Opts[A]
   ): Command[A] = {
-    val maybeHelp = if (helpFlag) Opts.help else Opts.never
+    val maybeHelp = helpFlag.getOrElse(Opts.never)
     new Command(name, header, maybeHelp orElse opts)
   }
 }
@@ -173,7 +173,7 @@ object Opts {
   def subcommands[A](head: Command[A], tail: Command[A]*): Opts[A] =
     NonEmptyList.of(head, tail: _*).map(subcommand(_)).reduce
 
-  def subcommand[A](name: String, help: String, helpFlag: Boolean = true)(
+  def subcommand[A](name: String, help: String, helpFlag: Option[Opts[Nothing]] = Some(Opts.help))(
       opts: Opts[A]
   ): Opts[A] = {
     Subcommand(Command(name, help, helpFlag)(opts))

--- a/core/shared/src/test/scala/com/monovore/decline/HelpSpec.scala
+++ b/core/shared/src/test/scala/com/monovore/decline/HelpSpec.scala
@@ -13,7 +13,7 @@ class HelpSpec extends AnyWordSpec with Matchers {
       val parser = Command(
         name = "program",
         header = "A header.",
-        helpFlag = false
+        helpFlag = None
       ) {
         val first = Opts.flag("first", short = "F", help = "First option.").orFalse
         val second = Opts.option[Long]("second", help = "Second option.").orNone
@@ -90,7 +90,7 @@ class HelpSpec extends AnyWordSpec with Matchers {
       val parser = Command(
         name = "program-test",
         header = "A header",
-        helpFlag = false
+        helpFlag = None
       ) {
         val first = Opts.flag("first", short = "F", help = "First option.").orFalse
         val second = Opts.option[Long]("second", help = "Second option.").orNone

--- a/core/shared/src/test/scala/com/monovore/decline/ParseSpec.scala
+++ b/core/shared/src/test/scala/com/monovore/decline/ParseSpec.scala
@@ -80,7 +80,7 @@ class ParseSpec extends AnyWordSpec with Matchers with Checkers {
 
 
   implicit class Parser[A](opts: Opts[A]) {
-    val command = Command("parse-spec", header = "Test command!", helpFlag = false)(opts)
+    val command = Command("parse-spec", header = "Test command!", helpFlag = None)(opts)
     def parse(args: Seq[String], env: Map[String, String] = Map()): Validated[List[String], A] = {
       Validated.fromEither(command.parse(args, env).swap.map(_.errors).swap)
     }

--- a/effect/shared/src/main/scala/com/monovore/decline/effect/CommandIOApp.scala
+++ b/effect/shared/src/main/scala/com/monovore/decline/effect/CommandIOApp.scala
@@ -10,7 +10,7 @@ import scala.language.higherKinds
 abstract class CommandIOApp(
     name: String,
     header: String,
-    helpFlag: Boolean = true,
+    helpFlag: Option[Opts[Nothing]] = Some(Opts.help),
     version: String = ""
 ) extends IOApp {
 
@@ -26,7 +26,7 @@ object CommandIOApp {
   def run[F[_]](
       name: String,
       header: String,
-      helpFlag: Boolean = true,
+      helpFlag: Option[Opts[Nothing]] = Some(Opts.help),
       version: Option[String] = None
   )(opts: Opts[F[ExitCode]], args: List[String])(implicit F: Sync[F]): F[ExitCode] =
     run(Command(name, header, helpFlag)(version.map(addVersionFlag(opts)).getOrElse(opts)), args)


### PR DESCRIPTION
As title says, I've added the chance to customize the help message directly passing an `Ops[Nothing]` that can be generated from any `Ops[Unit]` calling `.asHelp` on it.

I changed the default help message, adding the `-h` shorthand according to the first point of [12 factor CLI apps](https://medium.com/@jdxcode/12-factor-cli-apps-dd3c227a0e46)

I want to point out that without this change it's absolutely possible but not handy (at least in my opinion) to modify the default help text for the whole app and every subcommand, setting `helpFlag` to `false` and passing an `Opt.flag(...).asHelp` as first subcommand

P.s. The type of `helpFlag` can be changed to a less ugly `Option[Ops[Unit]]` that can be mapped with `_.asHelp`