### PR TITLE
Allow help text rendering to be customized

### DIFF
--- a/core/shared/src/main/scala/com/monovore/decline/CommandApp.scala
+++ b/core/shared/src/main/scala/com/monovore/decline/CommandApp.scala
@@ -20,21 +20,17 @@ package com.monovore.decline
  * This should now behave like any other object with a main method -- for example, on the JVM, this
  * could be invoked as `java myapp.MyApp --fantastic`.
  */
-abstract class CommandApp(command: Command[Unit], helpPrinter: Help.Printer) {
-
-  def this(command: Command[Unit]) =
-    this(command, Help.defaultPrinter)
+abstract class CommandApp(command: Command[Unit]) {
 
   def this(
       name: String,
       header: String,
       main: Opts[Unit],
       helpFlag: Boolean = true,
-      version: String = "",
-      helpPrinter: Help.Printer = Help.defaultPrinter
+      version: String = ""
   ) {
 
-    this({
+    this {
       val showVersion =
         if (version.isEmpty) Opts.never
         else
@@ -43,8 +39,13 @@ abstract class CommandApp(command: Command[Unit], helpPrinter: Help.Printer) {
             .map(_ => System.err.println(version))
 
       Command(name, header, helpFlag)(showVersion orElse main)
-    }, helpPrinter)
+    }
   }
+
+  /**
+   * This method can be overridden to replace the default renderer with a custom one.
+   */
+  def renderHelp(help: Help): String = Help.defaultRenderer(help)
 
   @deprecated(
     """
@@ -54,7 +55,7 @@ For suggested usage, see: http://monovore.com/decline/usage.html#defining-an-app
   )
   final def main(args: Array[String]): Unit =
     command.parse(PlatformApp.ambientArgs getOrElse args, sys.env) match {
-      case Left(help) => System.err.println(helpPrinter(help))
+      case Left(help) => System.err.println(renderHelp(help))
       case Right(_) => ()
     }
 }

--- a/core/shared/src/main/scala/com/monovore/decline/CommandApp.scala
+++ b/core/shared/src/main/scala/com/monovore/decline/CommandApp.scala
@@ -20,17 +20,18 @@ package com.monovore.decline
  * This should now behave like any other object with a main method -- for example, on the JVM, this
  * could be invoked as `java myapp.MyApp --fantastic`.
  */
-abstract class CommandApp(command: Command[Unit]) {
+abstract class CommandApp(command: Command[Unit], helpPrinter: Help.Printer) {
 
   def this(
       name: String,
       header: String,
       main: Opts[Unit],
       helpFlag: Boolean = true,
-      version: String = ""
+      version: String = "",
+      helpPrinter: Help.Printer = Help.defaultPrinter
   ) {
 
-    this {
+    this({
       val showVersion =
         if (version.isEmpty) Opts.never
         else
@@ -39,7 +40,7 @@ abstract class CommandApp(command: Command[Unit]) {
             .map(_ => System.err.println(version))
 
       Command(name, header, helpFlag)(showVersion orElse main)
-    }
+    }, helpPrinter)
   }
 
   @deprecated(
@@ -50,7 +51,7 @@ For suggested usage, see: http://monovore.com/decline/usage.html#defining-an-app
   )
   final def main(args: Array[String]): Unit =
     command.parse(PlatformApp.ambientArgs getOrElse args, sys.env) match {
-      case Left(help) => System.err.println(help)
+      case Left(help) => System.err.println(helpPrinter(help))
       case Right(_) => ()
     }
 }

--- a/core/shared/src/main/scala/com/monovore/decline/CommandApp.scala
+++ b/core/shared/src/main/scala/com/monovore/decline/CommandApp.scala
@@ -22,6 +22,9 @@ package com.monovore.decline
  */
 abstract class CommandApp(command: Command[Unit], helpPrinter: Help.Printer) {
 
+  def this(command: Command[Unit]) =
+    this(command, Help.defaultPrinter)
+
   def this(
       name: String,
       header: String,

--- a/core/shared/src/main/scala/com/monovore/decline/Help.scala
+++ b/core/shared/src/main/scala/com/monovore/decline/Help.scala
@@ -31,14 +31,12 @@ case class Help(
 object Help {
 
   /**
-   * The `Help.Printer` is used to render the help text which is displayed in the terminal.
+   * This function is used to render the help text which is displayed in the terminal.
    *
    * A simple function that returns a `String` is very flexible but also requires the user
-   * to do all formatting themselves.
+   * to do all formatting themselves. They can, of course, reuse functions from this module.
    */
-  type Printer = Help => String
-
-  val defaultPrinter: Help.Printer = (help: Help) => help.toString
+  val defaultRenderer: Help => String = (help: Help) => help.toString
 
   implicit val declineHelpShow: Show[Help] =
     Show.fromToString[Help]

--- a/core/shared/src/main/scala/com/monovore/decline/Help.scala
+++ b/core/shared/src/main/scala/com/monovore/decline/Help.scala
@@ -30,6 +30,16 @@ case class Help(
 
 object Help {
 
+  /**
+   * The `Help.Printer` is used to render the help text which is displayed in the terminal.
+   *
+   * A simple function that returns a `String` is very flexible but also requires the user
+   * to do all formatting themselves.
+   */
+  type Printer = Help => String
+
+  val defaultPrinter: Help.Printer = (help: Help) => help.toString
+
   implicit val declineHelpShow: Show[Help] =
     Show.fromToString[Help]
 


### PR DESCRIPTION
Hi,

I've been using decline for my projects for a while now, thanks for the great library!

I've started using [the official Github cli](https://github.com/cli/cli) and it feels great to use. One of the things I like is the clear help text structure it has. Large cli applications like `gh` or `brew` structure their help text by topic rather than just list all options and flags and I think it's easier to find what you need (see screenshots below).

I tried to keep this change minimal. It just enables people like me to provide their own help text rendering function instead of the default one in decline. I know that you don't want to innovate on the bash side, so I hope this doesn't automatically disqualify.

Of course, I will change the PR however you like. For example I could call the function `Formatter` instead of `Printer`. I only used the latter because `circe` does so as well. 
Also if you feel this feature is too specific to be included in the arguments of `CommandApp` and `CommandIOApp`, I could also change it to a member of those classes, which can be overridden. That way it's less front and center.

Cheers
~ Felix

Screenshots of other CLIs that use a topic structure in their help text:
<img src="https://i.imgur.com/7NiLbd8.png" width="600" >
<img src="https://i.imgur.com/kL7ibQW.png" width="300" >