### PR TITLE
Also allow Duration argument to parse "infinity"

### DIFF
--- a/core/shared/src/main/scala/com/monovore/decline/Argument.scala
+++ b/core/shared/src/main/scala/com/monovore/decline/Argument.scala
@@ -185,8 +185,14 @@ object Argument extends PlatformArguments {
 
   implicit val readDuration: Argument[Duration] =
     from("duration") { string =>
-      try Validated.Valid(Duration(string))
-      catch { case _: NumberFormatException => Validated.invalidNel(s"Invalid Duration: $string") }
+      try {
+        string match {
+          case "infinity" => Validated.Valid(Duration.Inf)
+          case s => Validated.Valid(Duration(s))
+        }
+      } catch {
+        case _: NumberFormatException => Validated.invalidNel(s"Invalid Duration: $string")
+      }
     }
 
   implicit val readFiniteDuration: Argument[FiniteDuration] =

--- a/core/shared/src/test/scala/com/monovore/decline/ArgumentSpec.scala
+++ b/core/shared/src/test/scala/com/monovore/decline/ArgumentSpec.scala
@@ -101,6 +101,10 @@ class ArgumentSpec extends ArgumentSuite {
     durationReader.read("+Inf").toOption should contain(Duration.Inf)
   }
 
+  test("Duration argument can correctly parse infinity") {
+    durationReader.read("infinity").toOption should contain(Duration.Inf)
+  }
+
   test("Duration argument can correctly parse -Inf") {
     durationReader.read("-Inf").toOption should contain(Duration.MinusInf)
   }


### PR DESCRIPTION
This PR allows the ability to parse `"infinity"` as a valid value for `Duration`. The primary reason for doing this change is that I noticed that akka libraries use "infinity" as a string value to designate `Duration.Inf` (i.e. https://github.com/akka/alpakka-kafka/blob/eb5246d3e03992ce60a1f33fefe75dadc58bc866/core/src/main/scala/akka/kafka/internal/ConfigSettings.scala#L44-L47)