### PR TITLE
Set project.git to true for .scalafmt.conf

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -2,3 +2,4 @@ version=2.7.5
 docstrings=JavaDoc
 maxColumn=100
 align.preset=none
+project.git=true


### PR DESCRIPTION
Set `project.git` to true, this makes scalafmt run faster by only formatting files which are designated as modified by git