### PR TITLE
Add support for java.time.temporal.ChronoUnit

### DIFF
--- a/core/jvm/src/main/scala/com/monovore/decline/PlatformArguments.scala
+++ b/core/jvm/src/main/scala/com/monovore/decline/PlatformArguments.scala
@@ -1,8 +1,9 @@
 package com.monovore.decline
 
-import java.nio.file.{InvalidPathException, Path, Paths}
-
 import cats.data.{Validated, ValidatedNel}
+
+import java.nio.file.{InvalidPathException, Path, Paths}
+import java.time.temporal.ChronoUnit
 
 private[decline] abstract class PlatformArguments {
 
@@ -17,5 +18,18 @@ private[decline] abstract class PlatformArguments {
       }
 
     override def defaultMetavar: String = "path"
+  }
+
+  implicit val readChronoUnit: Argument[ChronoUnit] = new Argument[ChronoUnit] {
+
+    override def read(string: String): ValidatedNel[String, ChronoUnit] =
+      try {
+        Validated.valid(ChronoUnit.valueOf(string.toUpperCase))
+      } catch {
+        case _: IllegalArgumentException =>
+          Validated.invalidNel(s"Invalid time unit: $string")
+      }
+
+    override def defaultMetavar: String = "time unit"
   }
 }

--- a/core/jvm/src/test/scala/com/monovore/decline/PlatformArgumentsSpec.scala
+++ b/core/jvm/src/test/scala/com/monovore/decline/PlatformArgumentsSpec.scala
@@ -1,12 +1,13 @@
 package com.monovore.decline
 
-import java.nio.file.{Path, Paths}
-
-import cats.data.Validated.Valid
+import cats.data.Validated.{Invalid, Valid}
 import org.scalacheck.Gen
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
+
+import java.nio.file.{Path, Paths}
+import java.time.temporal.ChronoUnit
 
 class PlatformArgumentsSpec extends AnyWordSpec with Matchers with ScalaCheckDrivenPropertyChecks {
 
@@ -27,6 +28,24 @@ class PlatformArgumentsSpec extends AnyWordSpec with Matchers with ScalaCheckDri
 
     "parse generated paths" in forAll(pathGen) { path =>
       Argument[Path].read(path.toString) should equal(Valid(path))
+    }
+  }
+
+  "ChronoUnit arguments" should {
+    val chronoUnitGen = Gen.oneOf(ChronoUnit.values().toList)
+
+    "parse valid ChronoUnit's successfully" in forAll(chronoUnitGen) { chronoUnit =>
+      Argument[ChronoUnit].read(chronoUnit.name()) should equal(Valid(chronoUnit))
+    }
+
+    "parse valid ChronoUnit's successfully in lowercase" in forAll(chronoUnitGen) { chronoUnit =>
+      Argument[ChronoUnit].read(chronoUnit.name().toLowerCase) should equal(Valid(chronoUnit))
+    }
+
+    "return error for invalid ChronoUnit's" in forAll(
+      Gen.alphaStr.filterNot(x => ChronoUnit.values().map(_.name()).contains(x))
+    ) { invalidChronoUnit =>
+      Argument[ChronoUnit].read(invalidChronoUnit) shouldBe a[Invalid[_]]
     }
   }
 


### PR DESCRIPTION
PR is quite self explanatory, adds support for `java.time.temporal.ChronoUnit` (only for the JVM since its not available on other platforms).