### PR TITLE
Accept `half-days` for ChronoUnit Argument

### DIFF
--- a/core/jvm/src/main/scala/com/monovore/decline/PlatformArguments.scala
+++ b/core/jvm/src/main/scala/com/monovore/decline/PlatformArguments.scala
@@ -24,7 +24,7 @@ private[decline] abstract class PlatformArguments {
 
     override def read(string: String): ValidatedNel[String, ChronoUnit] =
       try {
-        Validated.valid(ChronoUnit.valueOf(string.toUpperCase))
+        Validated.valid(ChronoUnit.valueOf(string.toUpperCase.replace('-', '_')))
       } catch {
         case _: IllegalArgumentException =>
           Validated.invalidNel(s"Invalid time unit: $string")

--- a/core/jvm/src/test/scala/com/monovore/decline/PlatformArgumentsSpec.scala
+++ b/core/jvm/src/test/scala/com/monovore/decline/PlatformArgumentsSpec.scala
@@ -42,6 +42,10 @@ class PlatformArgumentsSpec extends AnyWordSpec with Matchers with ScalaCheckDri
       Argument[ChronoUnit].read(chronoUnit.name().toLowerCase) should equal(Valid(chronoUnit))
     }
 
+    "parse half-days as a ChronoUnit value" in {
+      Argument[ChronoUnit].read("half-days") should equal(Valid(ChronoUnit.HALF_DAYS))
+    }
+
     "return error for invalid ChronoUnit's" in forAll(
       Gen.alphaStr.filterNot(x => ChronoUnit.values().map(_.name()).contains(x))
     ) { invalidChronoUnit =>


### PR DESCRIPTION
This is a quick solution for https://github.com/bkirwi/decline/issues/335 which just replaces `_` with `-` so that `half-days` is an acceptable command line argument (as well as `half_days`)

There is an argument that we should do a nicer solution like what is done in pureconf, i.e. support for converting from one case to another (and vice versa) but this is a bigger task.