### PR TITLE
Update scalafmt

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -23,4 +23,4 @@ jobs:
       - name: Check project is formatted
         uses: jrouly/scalafmt-native-action@v1
         with:
-          version: '2.7.5'
+          version: '3.0.3'

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,5 +1,5 @@
-version=2.7.5
-docstrings=JavaDoc
+version=3.0.3
+docstrings.style=asterisk
 maxColumn=100
 align.preset=none
 project.git=true

--- a/core/js/src/main/scala/com/monovore/decline/PlatformApp.scala
+++ b/core/js/src/main/scala/com/monovore/decline/PlatformApp.scala
@@ -16,6 +16,9 @@ object PlatformApp {
     def argv: js.Array[String] = js.native
   }
 
-  /** Returns `Some(argument list)` when compiled with Scala.js and running under Node.js, and `None` otherwise. */
+  /**
+   * Returns `Some(argument list)` when compiled with Scala.js and running under Node.js, and `None`
+   * otherwise.
+   */
   def ambientArgs: Option[Seq[String]] = Process.process.toOption.map { _.argv.drop(2).toSeq }
 }

--- a/core/jvm/src/main/scala/com/monovore/decline/PlatformApp.scala
+++ b/core/jvm/src/main/scala/com/monovore/decline/PlatformApp.scala
@@ -2,6 +2,9 @@ package com.monovore.decline
 
 object PlatformApp {
 
-  /** Returns `Some(argument list)` when compiled with Scala.js and running under Node.js, and `None` otherwise. */
+  /**
+   * Returns `Some(argument list)` when compiled with Scala.js and running under Node.js, and `None`
+   * otherwise.
+   */
   def ambientArgs: Option[Seq[String]] = None
 }

--- a/core/native/src/main/scala/com/monovore/decline/PlatformApp.scala
+++ b/core/native/src/main/scala/com/monovore/decline/PlatformApp.scala
@@ -2,6 +2,9 @@ package com.monovore.decline
 
 object PlatformApp {
 
-  /** Returns `Some(argument list)` when compiled with Scala.js and running under Node.js, and `None` otherwise. */
+  /**
+   * Returns `Some(argument list)` when compiled with Scala.js and running under Node.js, and `None`
+   * otherwise.
+   */
   def ambientArgs: Option[Seq[String]] = None
 }

--- a/core/shared/src/main/scala/com/monovore/decline/Argument.scala
+++ b/core/shared/src/main/scala/com/monovore/decline/Argument.scala
@@ -20,8 +20,8 @@ import scala.concurrent.duration.{Duration, FiniteDuration}
 trait Argument[A] { self =>
 
   /**
-   * Attempt to parse a single command-line argument: given an argument, this returns either
-   * the parsed value or a message explaining the failure.
+   * Attempt to parse a single command-line argument: given an argument, this returns either the
+   * parsed value or a message explaining the failure.
    */
   def read(string: String): ValidatedNel[String, A]
 

--- a/core/shared/src/main/scala/com/monovore/decline/opts.scala
+++ b/core/shared/src/main/scala/com/monovore/decline/opts.scala
@@ -4,8 +4,8 @@ import cats.{Alternative, Monoid}
 import cats.data.{NonEmptyList, Validated, ValidatedNel}
 
 /**
- * A top-level argument parser, with all the info necessary to parse a full
- * set of arguments or display a useful help text.
+ * A top-level argument parser, with all the info necessary to parse a full set of arguments or
+ * display a useful help text.
  */
 class Command[+A] private[decline] (
     val name: String,


### PR DESCRIPTION
This PR updates scalafmt. Note that the new scalafmt also correctly formats docstrings hence the reason for the diff.