### PR TITLE
Support for options with optional arguments 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,8 @@ project/*
 target/
 _site/
 .bsp/
+
+# Metals and VSCode stuff
+.metals/**
+.bloop/**
+.vscode/**

--- a/core/shared/src/main/scala/com/monovore/decline/Help.scala
+++ b/core/shared/src/main/scala/com/monovore/decline/Help.scala
@@ -118,7 +118,15 @@ object Help {
           )
         case (Opt.OptionalOptArg(names, metavar, help, _), _) =>
           List(
-            withIndent(4, names.map(name => s"$name[=<$metavar>]").mkString(", ")),
+            withIndent(
+              4,
+              names
+                .map {
+                  case Opts.ShortName(flag) => s"-$flag[<$metavar>]"
+                  case Opts.LongName(flag) => s"--$flag[=<$metavar>]"
+                }
+                .mkString(", ")
+            ),
             withIndent(8, help)
           )
         case (Opt.Argument(_), _) => Nil

--- a/core/shared/src/main/scala/com/monovore/decline/Help.scala
+++ b/core/shared/src/main/scala/com/monovore/decline/Help.scala
@@ -116,7 +116,12 @@ object Help {
             withIndent(4, names.mkString(", ")),
             withIndent(8, help)
           )
-        case _ => Nil
+        case (Opt.OptionalOptArg(names, metavar, help, _), _) =>
+          List(
+            withIndent(4, names.map(name => s"$name[=<$metavar>]").mkString(", ")),
+            withIndent(8, help)
+          )
+        case (Opt.Argument(_), _) => Nil
       }
 
   private def withIndent(indent: Int, s: String): String =

--- a/core/shared/src/main/scala/com/monovore/decline/Parser.scala
+++ b/core/shared/src/main/scala/com/monovore/decline/Parser.scala
@@ -131,12 +131,10 @@ private[decline] case class Parser[+A](command: Command[A])
 
 private[decline] object Parser {
 
-  type FlagOrArg = Option[String]
-
   sealed trait Match[+A]
   case class MatchFlag[A](next: A) extends Match[A]
   case class MatchOption[A](next: String => A) extends Match[A]
-  case class MatchOptArg[A](next: FlagOrArg => A) extends Match[A]
+  case class MatchOptArg[A](next: Option[String] => A) extends Match[A]
   case object MatchAmbiguous extends Match[Nothing]
 
   object Match {
@@ -317,10 +315,8 @@ private[decline] object Parser {
     ) extends Accumulator[NonEmptyList[Option[String]]] {
 
       override def parseOption(name: Opts.Name) =
-        if (names contains name) Some(MatchOptArg {
-          case Some(value) => copy(reversedValues = Some(value) :: reversedValues)
-          case None => copy(reversedValues = None :: reversedValues)
-        })
+        if (names contains name)
+          Some(MatchOptArg(arg => copy(reversedValues = arg :: reversedValues)))
         else None
 
       override def parseSub(command: String) = None

--- a/core/shared/src/main/scala/com/monovore/decline/opts.scala
+++ b/core/shared/src/main/scala/com/monovore/decline/opts.scala
@@ -2,6 +2,7 @@ package com.monovore.decline
 
 import cats.{Alternative, Monoid}
 import cats.data.{NonEmptyList, Validated, ValidatedNel}
+import cats.syntax.traverse._
 
 /**
  * A top-level argument parser, with all the info necessary to parse a full set of arguments or
@@ -133,6 +134,33 @@ object Opts {
     Single(Opt.Regular(namesFor(long, short), metavarFor[A](metavar), help, visibility))
       .mapValidated(Argument[A].read)
 
+  def optionalOptArg[A](
+      long: String,
+      help: String,
+      short: String = "",
+      metavar: String = "",
+      visibility: Visibility = Visibility.Normal
+  )(implicit arg: Argument[A]): Opts[Option[A]] =
+    Single(Opt.OptionalOptArg(namesFor(long, short), metavarFor[A](metavar), help, visibility))
+      .mapValidated {
+        case None => Validated.Valid(None)
+        case Some(value) => arg.read(value).map(Some(_))
+      }
+
+  def optionalOptArgs[A](
+      long: String,
+      help: String,
+      short: String = "",
+      metavar: String = "",
+      visibility: Visibility = Visibility.Normal
+  )(implicit arg: Argument[A]): Opts[(Int, List[A])] =
+    Repeated(Opt.OptionalOptArg(namesFor(long, short), metavarFor[A](metavar), help, visibility))
+      .mapValidated(nel => {
+        val flags = nel.toList.count(_.isEmpty)
+        val optionArgs = nel.toList.collect { case Some(value) => value }
+        optionArgs.traverse[ValidatedNel[String, *], A](arg.read).map(optArgs => (flags, optArgs))
+      })
+
   def options[A: Argument](
       long: String,
       help: String,
@@ -193,6 +221,12 @@ private[decline] object Opt {
 
   case class Regular(names: List[Name], metavar: String, help: String, visibility: Visibility)
       extends Opt[String]
+  case class OptionalOptArg(
+      names: List[Name],
+      metavar: String,
+      help: String,
+      visibility: Visibility
+  ) extends Opt[Option[String]]
   case class Flag(names: List[Name], help: String, visibility: Visibility) extends Opt[Unit]
   case class Argument(metavar: String) extends Opt[String]
 }

--- a/core/shared/src/test/scala/com/monovore/decline/HelpSpec.scala
+++ b/core/shared/src/test/scala/com/monovore/decline/HelpSpec.scala
@@ -19,17 +19,30 @@ class HelpSpec extends AnyWordSpec with Matchers {
         val second = Opts.option[Long]("second", help = "Second option.").orNone
         val third = Opts.option[Long]("third", help = "Third option.") orElse
           Opts.env[Long]("THIRD", help = "Third option env.")
-        val fourth = Opts.flagOption[String]("fourth", help ="Fourth option.", metavar="string").orNone
+        val flagOpt = Opts
+          .flagOption[String](
+            "flagOpt",
+            help = "Flag option - can either be a flag or an option-argument.",
+            metavar = "string"
+          )
+          .orNone
+
+        val flagOpts = Opts.flagOptions[String](
+          "flag",
+          help = "...",
+          metavar = "string"
+        )
         val subcommands =
           Opts.subcommand("run", "Run a task?") {
             Opts.argument[String]("task")
           }
 
-        (first, second, third, fourth, subcommands).tupled
+        (first, second, third, flagOpt, flagOpts, subcommands).tupled
       }
 
+      // println(Help.fromCommand(parser))
       Help.fromCommand(parser).toString should equal(
-        """Usage: program [--first] [--second <integer>] [--third <integer>] run
+        """Usage: program [--first] [--second <integer>] [--third <integer>] [--flagOpt[=<string>]] --flag[=<string>] [--flag[=<string>]]... run
           |
           |A header.
           |
@@ -40,8 +53,10 @@ class HelpSpec extends AnyWordSpec with Matchers {
           |        Second option.
           |    --third <integer>
           |        Third option.
-          |    --fourth[=<string>]
-          |        Fourth option.
+          |    --flagOpt[=<string>]
+          |        Flag option - can either be a flag or an option-argument.
+          |    --flag[=<string>]
+          |        ...
           |
           |Environment Variables:
           |    THIRD=<integer>

--- a/core/shared/src/test/scala/com/monovore/decline/HelpSpec.scala
+++ b/core/shared/src/test/scala/com/monovore/decline/HelpSpec.scala
@@ -23,14 +23,16 @@ class HelpSpec extends AnyWordSpec with Matchers {
           .flagOption[String](
             "flagOpt",
             help = "Flag option - can either be a flag or an option-argument.",
-            metavar = "string"
+            metavar = "string",
+            short = "l"
           )
           .orNone
 
         val flagOpts = Opts.flagOptions[String](
           "flag",
           help = "...",
-          metavar = "string"
+          metavar = "string",
+          short = "Ff"
         )
         val subcommands =
           Opts.subcommand("run", "Run a task?") {
@@ -40,7 +42,6 @@ class HelpSpec extends AnyWordSpec with Matchers {
         (first, second, third, flagOpt, flagOpts, subcommands).tupled
       }
 
-      // println(Help.fromCommand(parser))
       Help.fromCommand(parser).toString should equal(
         """Usage: program [--first] [--second <integer>] [--third <integer>] [--flagOpt[=<string>]] --flag[=<string>] [--flag[=<string>]]... run
           |
@@ -53,9 +54,9 @@ class HelpSpec extends AnyWordSpec with Matchers {
           |        Second option.
           |    --third <integer>
           |        Third option.
-          |    --flagOpt[=<string>]
+          |    --flagOpt[=<string>], -l[<string>]
           |        Flag option - can either be a flag or an option-argument.
-          |    --flag[=<string>]
+          |    --flag[=<string>], -F[<string>], -f[<string>]
           |        ...
           |
           |Environment Variables:

--- a/core/shared/src/test/scala/com/monovore/decline/HelpSpec.scala
+++ b/core/shared/src/test/scala/com/monovore/decline/HelpSpec.scala
@@ -19,12 +19,13 @@ class HelpSpec extends AnyWordSpec with Matchers {
         val second = Opts.option[Long]("second", help = "Second option.").orNone
         val third = Opts.option[Long]("third", help = "Third option.") orElse
           Opts.env[Long]("THIRD", help = "Third option env.")
+        val fourth = Opts.flagOption[String]("fourth", help ="Fourth option.", metavar="string").orNone
         val subcommands =
           Opts.subcommand("run", "Run a task?") {
             Opts.argument[String]("task")
           }
 
-        (first, second, third, subcommands).tupled
+        (first, second, third, fourth, subcommands).tupled
       }
 
       Help.fromCommand(parser).toString should equal(
@@ -39,6 +40,8 @@ class HelpSpec extends AnyWordSpec with Matchers {
           |        Second option.
           |    --third <integer>
           |        Third option.
+          |    --fourth[=<string>]
+          |        Fourth option.
           |
           |Environment Variables:
           |    THIRD=<integer>

--- a/core/shared/src/test/scala/com/monovore/decline/ParseSpec.scala
+++ b/core/shared/src/test/scala/com/monovore/decline/ParseSpec.scala
@@ -86,6 +86,82 @@ class ParseSpec extends AnyWordSpec with Matchers with Checkers {
 
   "Parsing" should {
 
+    "read optional option arguments" should {
+      val color = Opts
+        .flagOption[String](long = "color", help = "...", short = "C")
+        .orNone
+
+      val all =
+        Opts
+          .flag(long = "all", help = "...", short = "a")
+          .orFalse
+
+      val repeatedFlagOpt = Opts
+        .flagOptions[String](long = "flag", help = "...", short = "f")
+        .map(_.toList)
+        .orElse(Opts.Pure(List.empty))
+
+      val allOpts = (color, all, repeatedFlagOpt).tupled
+
+      case class LsTestCase(
+          args: List[String],
+          expected: Validated[List[
+            String
+          ], (Option[Option[String]], Boolean, List[Option[String]])]
+      )
+
+      val testCases = List(
+        LsTestCase(
+          args = List("--color", "--all"),
+          expected = Valid((Some(None), true, Nil))
+        ),
+        LsTestCase(
+          args = List("--all", "--color"),
+          expected = Valid((Some(None), true, Nil))
+        ),
+        LsTestCase(
+          args = List("--color", "-af"),
+          expected = Valid((Some(None), true, List(None)))
+        ),
+        LsTestCase(
+          args = List("--all", "--color", "always"),
+          expected = Invalid(List("Unexpected argument: always"))
+        ),
+        LsTestCase(
+          args = List("--color=always"),
+          expected = Valid((Some(Some("always")), false, Nil))
+        ),
+        LsTestCase(
+          args = List("-aC"),
+          expected = Valid((Some(None), true, Nil))
+        ),
+        LsTestCase(
+          args = List("-Ca"),
+          expected = Valid((Some(Some("a")), false, Nil))
+        ),
+        LsTestCase(
+          args = List(),
+          expected = Valid((None, false, Nil))
+        ),
+        LsTestCase(
+          args = List("--flag", "-Cok", "-af", "--flag=hi", "--flag=there"),
+          expected = Valid((Some(Some("ok")), true, List(None, None, Some("hi"), Some("there"))))
+        ),
+        LsTestCase(
+          args = List("-ffff\"hey guys\""),
+          expected = Valid((None, false, List(Some("fff\"hey guys\""))))
+        )
+      )
+
+      testCases.foreach { case LsTestCase(args, expected) =>
+        registerTest(s"""read "ls ${args.mkString(" ")}"""") {
+          val parsed = allOpts.parse(args, Map.empty)
+          assert(parsed == expected)
+        }
+      }
+
+    }
+
     "meet the alternative laws" in {
 
       implicit val ints: Arbitrary[Opts[Int]] = Arbitrary(gen.intOpts)
@@ -376,87 +452,6 @@ class ParseSpec extends AnyWordSpec with Matchers with Checkers {
           val Invalid(errs) = opts.parse(List(), Map("WHATEVER" -> "invalidint"))
           errs should equal(List("Invalid integer: invalidint"))
         }
-      }
-
-      "optional option arguments" should {
-        val color = Opts
-          .flagOption[String](
-            long = "color",
-            help = "colorize the output",
-            short = "C",
-            metavar = "WHEN"
-          )
-          .orNone
-
-        val all =
-          Opts
-            .flag(long = "all", help = "do not ignore entries starting with .", short = "a")
-            .orFalse
-
-        val repeatedFlagOpt = Opts
-          .flagOptions[String](long = "flag", help = "...", short = "f")
-          .map(_.toList)
-          .orElse(Opts.Pure(List.empty))
-
-        val allOpts = (color, all, repeatedFlagOpt).tupled
-
-        case class LsTestCase(
-            args: List[String],
-            expected: Validated[List[
-              String
-            ], (Option[Option[String]], Boolean, List[Option[String]])]
-        )
-
-        val testCases = List(
-          LsTestCase(
-            args = List("--color", "--all"),
-            expected = Valid((Some(None), true, Nil))
-          ),
-          LsTestCase(
-            args = List("--all", "--color"),
-            expected = Valid((Some(None), true, Nil))
-          ),
-          LsTestCase(
-            args = List("--color", "-af"),
-            expected = Valid((Some(None), true, List(None)))
-          ),
-          LsTestCase(
-            args = List("--all", "--color", "always"),
-            expected = Invalid(List("Unexpected argument: always"))
-          ),
-          LsTestCase(
-            args = List("--color=always"),
-            expected = Valid((Some(Some("always")), false, Nil))
-          ),
-          LsTestCase(
-            args = List("-aC"),
-            expected = Valid((Some(None), true, Nil))
-          ),
-          LsTestCase(
-            args = List("-Ca"),
-            expected = Valid((Some(Some("a")), false, Nil))
-          ),
-          LsTestCase(
-            args = List(),
-            expected = Valid((None, false, Nil))
-          ),
-          LsTestCase(
-            args = List("--flag", "-Cok", "-af", "--flag=hi", "--flag=there"),
-            expected = Valid((Some(Some("ok")), true, List(None, None, Some("hi"), Some("there"))))
-          ),
-          LsTestCase(
-            args = List("-ffff\"hey guys\""),
-            expected = Valid((None, false, List(Some("fff\"hey guys\""))))
-          ),
-        )
-
-        testCases.foreach { case LsTestCase(args, expected) =>
-          registerTest(s"ls ${args.mkString(" ")}") {
-            val parsed = allOpts.parse(args, Map.empty)
-            assert(parsed == expected)
-          }
-        }
-
       }
     }
   }

--- a/core/shared/src/test/scala/com/monovore/decline/ParseSpec.scala
+++ b/core/shared/src/test/scala/com/monovore/decline/ParseSpec.scala
@@ -98,8 +98,7 @@ class ParseSpec extends AnyWordSpec with Matchers with Checkers {
 
       val repeatedFlagOpt = Opts
         .flagOptions[String](long = "flag", help = "...", short = "f")
-        .map(_.toList)
-        .orElse(Opts.Pure(List.empty))
+        .orEmpty
 
       val allOpts = (color, all, repeatedFlagOpt).tupled
 

--- a/core/shared/src/test/scala/com/monovore/decline/UsageSpec.scala
+++ b/core/shared/src/test/scala/com/monovore/decline/UsageSpec.scala
@@ -22,5 +22,17 @@ class UsageSpec extends AnyWordSpec with Matchers {
         .flatMap { _.show }
       usage should equal(List("[--whatever <integer>]"))
     }
+
+    "display optional option-arguments correctly" in {
+      val usage =
+        Usage.fromOpts(Opts.flagOption[String]("flagOpt", "...")).flatMap(_.show)
+
+      usage should equal(
+        List(
+          "--flagOpt[=<string>]"
+        )
+      )
+
+    }
   }
 }


### PR DESCRIPTION
An attempt to solve https://github.com/bkirwi/decline/issues/350. 

For now, it is unclear how an option with optional arguments should be parsed in presence of other options.
For long options, I suggest the following strategy:
* If the next arguments is special, e.g. an option or `--`, this argument should not be consumed and the option with optional argument should be considered empty. 
* Otherwise, the next agument should be consumed.

As for short options, the behavior should be the following (from what I understood of the [POSIX Utitility specification, section 2.b](https://pubs.opengroup.org/onlinepubs/9699919799/)):
* if the option with an optional option-argument is the last in the string of flags, it should be consumed as empty.
* Otherwise, this option should consume the entire remaining string of flags as its option argument.

@bkirwi what do you think?