### PR TITLE
Be lazy in defaults

### DIFF
--- a/core/shared/src/main/scala/com/monovore/decline/opts.scala
+++ b/core/shared/src/main/scala/com/monovore/decline/opts.scala
@@ -57,7 +57,7 @@ sealed trait Opts[+A] {
 
   def orElse[A0 >: A](other: Opts[A0]): Opts[A0] = Opts.OrElse(this, other)
 
-  def withDefault[A0 >: A](default: A0): Opts[A0] =
+  def withDefault[A0 >: A](default: => A0): Opts[A0] =
     this orElse Opts.apply(default)
 
   def orNone: Opts[Option[A]] =

--- a/core/shared/src/test/scala/com/monovore/decline/ParseSpec.scala
+++ b/core/shared/src/test/scala/com/monovore/decline/ParseSpec.scala
@@ -453,5 +453,14 @@ class ParseSpec extends AnyWordSpec with Matchers with Checkers {
         }
       }
     }
+
+    "be lazy in defaults" in {
+      val opts1 = Opts.option[Int](long = "number", help = "").withDefault(throw new RuntimeException("boom"))
+      intercept[RuntimeException] {
+        opts1.parse(Nil)
+      }
+      val opts2 = Opts.option[Int](long = "number", help = "").withDefault(throw new RuntimeException("boom"))
+      opts2.parse(List("--number", "1")) should equal(Valid(1))
+    }
   }
 }


### PR DESCRIPTION
This is useful, for example, if you want to allow a temp file as an argument, but if none is provided calling Files.createTempFile.