### PR TITLE
Handle the empty-optional case correctly

### DIFF
--- a/core/shared/src/main/scala/com/monovore/decline/Usage.scala
+++ b/core/shared/src/main/scala/com/monovore/decline/Usage.scala
@@ -16,26 +16,6 @@ private[decline] case class Usage(opts: Many[Options] = Prod(), args: Many[Args]
 
 private[decline] object Usage {
 
-  // TODO: convert arg list representation to 'normal form'... ie. the most restrictive usage
-  // text we can write that captures all uses
-  // [<a>] [<b>] --> [<a> [<b>]]
-  // [<a>] <b> --> <a> <b>
-  // <a>... <b> -> none
-  // <a>... [<b>] -> <a...>
-  // <a>... <b>... -> none
-  // <a> (<b> | <c> <d>) -> <a> <b>, <a> <c> <d>
-  // (<a> | <b> <c>) <d> -> <b> <c> <d>
-  // <a> (<b> | <c> <d>) ->
-  // command <a> -> <a> command   ????
-  // command [<a>] -> <a> command ????
-  // command command -> none
-  // <a>... command -> none
-  // [<a>...] command -> none (too many!)
-  // [<a> | <b> <c>] --> [<a> | <b> <c>]
-  // [<a> | <b> <c>] <d> --> <b> <c> <d>
-  // if i am mandatory, everyone to the left is interpreted 'as big as possible'
-  // if i am repeating, everyone on the right is interpreted as 'empty or fail'
-
   sealed trait Many[A] {
     def asProd: Prod[A] = Prod(this)
     def asSum: Sum[A] = Sum(this)

--- a/core/shared/src/main/scala/com/monovore/decline/Usage.scala
+++ b/core/shared/src/main/scala/com/monovore/decline/Usage.scala
@@ -76,6 +76,8 @@ private[decline] object Usage {
 
   def concat(all: Iterable[String]) = all.filter { _.nonEmpty }.mkString(" ")
 
+  def alt(all: Iterable[String]) = if (all.isEmpty) None else Some(all.mkString("[", " | ", "]"))
+
   def single(opt: Opt[_]): List[Usage] = opt match {
     case Opt.Flag(names, _, Visibility.Normal) =>
       List(Usage(opts = Just(Options.Required(s"${names.head}"))))
@@ -113,7 +115,7 @@ private[decline] object Usage {
     case Prod(many @ _*) => many.toList.traverse(showArgs).map(concat)
     case Sum(many @ _*) =>
       asOptional(many.toList)
-        .map(opt => opt.traverse(showArgs).map { _.mkString("[", " | ", "]") })
+        .map(opt => opt.traverse(showArgs).flatMap(args => alt(args)))
         .getOrElse(many.flatMap(showArgs).toList)
     case Just(Args.Required(meta)) => List(meta)
     case Just(Args.Repeated(meta)) => List(s"$meta...")
@@ -125,7 +127,7 @@ private[decline] object Usage {
       asOptional(alternatives.toList)
         .map {
           case Seq(Just(Options.Repeated(a))) => List(s"[$a]...")
-          case filtered => filtered.traverse(showOptions).map(_.mkString("[", " | ", "]"))
+          case filtered => filtered.traverse(showOptions).flatMap(args => alt(args))
         }
         .getOrElse { alternatives.toList.flatMap(showOptions) }
     }

--- a/core/shared/src/main/scala/com/monovore/decline/Usage.scala
+++ b/core/shared/src/main/scala/com/monovore/decline/Usage.scala
@@ -56,7 +56,7 @@ private[decline] object Usage {
 
   def concat(all: Iterable[String]) = all.filter { _.nonEmpty }.mkString(" ")
 
-  def alt(all: Iterable[String]) = if (all.isEmpty) None else Some(all.mkString("[", " | ", "]"))
+  def alt(all: Iterable[String]) = if (all.isEmpty) "" else all.mkString("[", " | ", "]")
 
   def single(opt: Opt[_]): List[Usage] = opt match {
     case Opt.Flag(names, _, Visibility.Normal) =>
@@ -95,7 +95,7 @@ private[decline] object Usage {
     case Prod(many @ _*) => many.toList.traverse(showArgs).map(concat)
     case Sum(many @ _*) =>
       asOptional(many.toList)
-        .map(opt => opt.traverse(showArgs).flatMap(args => alt(args)))
+        .map(opt => opt.traverse(showArgs).map(args => alt(args)))
         .getOrElse(many.flatMap(showArgs).toList)
     case Just(Args.Required(meta)) => List(meta)
     case Just(Args.Repeated(meta)) => List(s"$meta...")
@@ -107,7 +107,7 @@ private[decline] object Usage {
       asOptional(alternatives.toList)
         .map {
           case Seq(Just(Options.Repeated(a))) => List(s"[$a]...")
-          case filtered => filtered.traverse(showOptions).flatMap(args => alt(args))
+          case filtered => filtered.traverse(showOptions).map(args => alt(args))
         }
         .getOrElse { alternatives.toList.flatMap(showOptions) }
     }

--- a/core/shared/src/test/scala/com/monovore/decline/UsageSpec.scala
+++ b/core/shared/src/test/scala/com/monovore/decline/UsageSpec.scala
@@ -11,7 +11,7 @@ class UsageSpec extends AnyWordSpec with Matchers {
     def show(opts: Opts[_]) = Usage.fromOpts(opts).flatMap(_.show)
 
     "handle no opts" in {
-      Usage.fromOpts(Opts.apply(15)) should equal(List(Usage()))
+      show(Opts.apply(15)) should equal(List(""))
     }
 
     "handle a single argument" in {
@@ -36,8 +36,18 @@ class UsageSpec extends AnyWordSpec with Matchers {
     }
 
     "discard empty alternatives" in {
-      assert(show(Opts("ok").withDefault("Hi")) == List())
-      assert(show(Opts.env[String]("YIKES", "...").withDefault("Hi")) == List())
+      assert(show(Opts("ok").withDefault("Hi")) == List(""))
+      assert(
+        show(
+          (
+            Opts.option[Int]("number", "Print N times", metavar = "N"),
+            Opts.env[String]("GREETING", "A greeting").withDefault("Hi"), // FIRST []
+            Opts.env[String]("BODY", "The content"), // NO DEFAULT - OK
+            Opts.env[String]("FOOTER", "Ending").withDefault("Best regards"), // SECOND []
+            Opts.option[String]("name", "Who to greet")
+          ).tupled
+        ) == List("--number <N> --name <string>")
+      )
     }
   }
 }

--- a/core/shared/src/test/scala/com/monovore/decline/UsageSpec.scala
+++ b/core/shared/src/test/scala/com/monovore/decline/UsageSpec.scala
@@ -2,37 +2,42 @@ package com.monovore.decline
 
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
+import cats.syntax.all._
 
 class UsageSpec extends AnyWordSpec with Matchers {
 
   "Usage" should {
+
+    def show(opts: Opts[_]) = Usage.fromOpts(opts).flatMap(_.show)
 
     "handle no opts" in {
       Usage.fromOpts(Opts.apply(15)) should equal(List(Usage()))
     }
 
     "handle a single argument" in {
-      val usage = Usage.fromOpts(Opts.option[Int]("foo", "...")).flatMap { _.show }
+      val usage = show(Opts.option[Int]("foo", "..."))
       usage should equal(List("--foo <integer>"))
     }
 
     "show environment variables combined with options as optional" in {
-      val usage = Usage
-        .fromOpts(Opts.option[Int]("whatever", "...") orElse Opts.env[Int]("WHATEVER", "..."))
-        .flatMap { _.show }
+      val usage = show(Opts.option[Int]("whatever", "...") orElse Opts.env[Int]("WHATEVER", "..."))
       usage should equal(List("[--whatever <integer>]"))
     }
 
     "display optional option-arguments correctly" in {
       val usage =
-        Usage.fromOpts(Opts.flagOption[String]("flagOpt", "...")).flatMap(_.show)
+        show(Opts.flagOption[String]("flagOpt", "..."))
 
       usage should equal(
         List(
           "--flagOpt[=<string>]"
         )
       )
+    }
 
+    "discard empty alternatives" in {
+      assert(show(Opts("ok").withDefault("Hi")) == List())
+      assert(show(Opts.env[String]("YIKES", "...").withDefault("Hi")) == List())
     }
   }
 }


### PR DESCRIPTION
The `Usage` rendering code tries to find groups of options that can be rendered using the `[--foo | --bar]` syntax -- effectively, a `Sum` that contains at least one empty `Prod`. However, if it contains _only_ empty `Prod`s, it will render as `[]`, which is nonstandard and not useful.

Previously, this would never arise in practise -- you'd need to write some weird opts instances like `Opts("foo").withDefault("bar")` to trigger it. However, as pointed out in #475, now that we have `Opts.env` this can arise with the much more reasonable `Opts.env(...).withDefault(...)`.

The proposed fix is to just filter out cases where the list of alternatives in the braces is empty. I'll want to do a little more testing before I'm confident in it, though.