### PR TITLE
Use cats.syntax.all instead of cats.implicits

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A composable command-line parser, inspired by [`optparse-applicative`][optparse]
 and built on [`cats`][cats].
 
 ```scala
-import cats.implicits._
+import cats.syntax.all._
 import com.monovore.decline._
 
 object HelloWorld extends CommandApp(

--- a/bench/src/main/scala/com/monovore/decline/bench/OptionSequence.scala
+++ b/bench/src/main/scala/com/monovore/decline/bench/OptionSequence.scala
@@ -2,7 +2,7 @@ package com.monovore.decline.bench
 
 import com.monovore.decline._
 import org.openjdk.jmh.annotations.Benchmark
-import cats.implicits._
+import cats.syntax.all._
 
 object OptionSequence {
 

--- a/bench/src/main/scala/com/monovore/decline/bench/SandwichedArgs.scala
+++ b/bench/src/main/scala/com/monovore/decline/bench/SandwichedArgs.scala
@@ -2,7 +2,7 @@ package com.monovore.decline.bench
 
 import com.monovore.decline._
 import org.openjdk.jmh.annotations.Benchmark
-import cats.implicits._
+import cats.syntax.all._
 
 object SandwichedArgs {
 

--- a/doc/src/main/tut/effect.md
+++ b/doc/src/main/tut/effect.md
@@ -34,7 +34,7 @@ And add the necessary imports:
 
 ```scala mdoc:to-string
 import cats.effect._
-import cats.implicits._
+import cats.syntax.all._
 
 import com.monovore.decline._
 import com.monovore.decline.effect._

--- a/doc/src/main/tut/index.md
+++ b/doc/src/main/tut/index.md
@@ -34,7 +34,7 @@ libraryDependencies += "com.monovore" %% "decline" % "@DECLINE_VERSION@"
 Then, write a program:
 
 ```scala mdoc:silent
-import cats.implicits._
+import cats.syntax.all._
 import com.monovore.decline._
 
 object HelloWorld extends CommandApp(

--- a/doc/src/main/tut/structure.md
+++ b/doc/src/main/tut/structure.md
@@ -25,7 +25,7 @@ and writes out the result to another file.
 
 ```scala mdoc:to-string
 import com.monovore.decline._
-import cats.implicits._
+import cats.syntax.all._
 
 import java.net.URI
 import scala.concurrent.duration.Duration

--- a/doc/src/main/tut/usage.md
+++ b/doc/src/main/tut/usage.md
@@ -118,7 +118,7 @@ You can combine multiple `Opts` instances
 using `cats`' [applicative syntax](http://typelevel.org/cats/typeclasses/apply.html#apply-builder-syntax):
 
 ```scala mdoc:to-string
-import cats.implicits._
+import cats.syntax.all._
 
 val tailOptions = (linesOrDefault, fileList).mapN { (n, files) =>
   println(s"LOG: Printing the last $n lines from each file in $files!")
@@ -129,7 +129,7 @@ val tailOptions = (linesOrDefault, fileList).mapN { (n, files) =>
 to compose into a larger `Opts` that yields a tuple:
 
 ```scala mdoc:to-string
-import cats.implicits._
+import cats.syntax.all._
 
 val tailOptionsTuple = (linesOrDefault, fileList).tupled
 ```


### PR DESCRIPTION
follow this pr: https://github.com/typelevel/cats/pull/4394 