### PR TITLE
Accumulate errors when reading Eithers

### DIFF
--- a/core/shared/src/main/scala/com/monovore/decline/Argument.scala
+++ b/core/shared/src/main/scala/com/monovore/decline/Argument.scala
@@ -131,8 +131,10 @@ object Argument extends PlatformArguments {
       override def combineK[A](x: Argument[A], y: Argument[A]): Argument[A] =
         from[A](s"${x.defaultMetavar} | ${y.defaultMetavar}") { string =>
           val ax = x.read(string)
-          if (ax.isValid) ax
-          else y.read(string)
+          ax match {
+            case Validated.Valid(a) => ax
+            case Validated.Invalid(e) => y.read(string).leftMap(e ++ _.toList)
+          }
         }
 
       /*

--- a/core/shared/src/test/scala/com/monovore/decline/ArgumentSpec.scala
+++ b/core/shared/src/test/scala/com/monovore/decline/ArgumentSpec.scala
@@ -3,6 +3,7 @@ package com.monovore.decline
 import com.monovore.decline.discipline.ArgumentSuite
 import cats.{Defer, SemigroupK, Show}
 import cats.data.Validated
+import cats.data.NonEmptyList
 import org.scalacheck.{Arbitrary, Gen}
 
 import java.util.UUID
@@ -151,6 +152,19 @@ class ArgumentSpec extends ArgumentSuite {
         .combineK(Argument[Int].map(_.toString), Argument[String])
         .defaultMetavar ==
         "integer | string"
+    )
+  }
+
+  test("Argument[Either[_, _]] accumulates errors") {
+    val arg = Argument[Either[Int, Char]]
+    val result = arg.read("abc")
+    assert(
+      result == Validated.Invalid(
+        NonEmptyList.of(
+          "Invalid character: abc",
+          "Invalid integer: abc"
+        )
+      )
     )
   }
 


### PR DESCRIPTION
This is useful feedback when both sides of the Either are invalid. You want to know why both sides failed, not just the Right