### PR TITLE
Fix: autoColors works in the opposite way

### DIFF
--- a/core/shared/src/main/scala/com/monovore/decline/HelpFormat.scala
+++ b/core/shared/src/main/scala/com/monovore/decline/HelpFormat.scala
@@ -133,7 +133,7 @@ object HelpFormat {
    * @return
    */
   def autoColors(env: Map[String, String]) =
-    Plain.withColors(colors = env.get("NO_COLOR").exists(_.nonEmpty))
+    Plain.withColors(colors = env.get("NO_COLOR").map(_ => false).getOrElse(true))
 }
 
 private[decline] case class Flags(

--- a/core/shared/src/main/scala/com/monovore/decline/HelpFormat.scala
+++ b/core/shared/src/main/scala/com/monovore/decline/HelpFormat.scala
@@ -127,13 +127,19 @@ object HelpFormat {
   /**
    * Format that disables colors when a `NO_COLOR` environment variable is present.
    *
+   * From https://no-color.org/
+   *
+   * "Command-line software which adds ANSI color to its output by default should check for a
+   * NO_COLOR environment variable that, when present and not an empty string (regardless of its
+   * value), prevents the addition of ANSI color."
+   *
    * Example usage: `autoColors(sys.env)`
    *
    * @param env
    * @return
    */
   def autoColors(env: Map[String, String]) =
-    Plain.withColors(colors = env.get("NO_COLOR").map(_ => false).getOrElse(true))
+    Plain.withColors(colors = env.getOrElse("NO_COLOR", "") == "")
 }
 
 private[decline] case class Flags(

--- a/core/shared/src/test/scala/com/monovore/decline/HelpFormatSpec.scala
+++ b/core/shared/src/test/scala/com/monovore/decline/HelpFormatSpec.scala
@@ -1,0 +1,25 @@
+package com.monovore.decline
+
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class HelpFormatSpec extends AnyWordSpec with Matchers {
+
+  "HelpFormat" should {
+    "respect NO_COLOR env variable in autoColors mode" in {
+      val absent = Map.empty[String, String]
+      val presentNonEmpty = Map("NO_COLOR" -> "1")
+      val presentEmpty = Map("NO_COLOR" -> "")
+
+      HelpFormat.autoColors(absent).colorsEnabled shouldEqual true
+      HelpFormat.autoColors(presentNonEmpty).colorsEnabled shouldEqual false
+      HelpFormat.autoColors(presentEmpty).colorsEnabled shouldEqual true
+
+      // testing the autoColors forwarder added directly to Help
+      Help.autoColors(absent).colorsEnabled shouldEqual true
+      Help.autoColors(presentNonEmpty).colorsEnabled shouldEqual false
+      Help.autoColors(presentEmpty).colorsEnabled shouldEqual true
+    }
+  }
+
+}


### PR DESCRIPTION
Whoops.

I reworked this condition because `exists` and `nonEmpty` made my head hurt a little bit.