### PR TITLE
Fix a bug rendering usage for some mutually-exclusive options

### DIFF
--- a/core/shared/src/main/scala/com/monovore/decline/Help.scala
+++ b/core/shared/src/main/scala/com/monovore/decline/Help.scala
@@ -79,15 +79,9 @@ class Help private (
     val usageSection =
       if (usages.isEmpty || !format.usageEnabled) Nil
       else {
-        usages match {
-          case Nil => List(theme.sectionHeading("Usage: ") + prefixString)
-          case only :: Nil =>
-            List(theme.sectionHeading("Usage: ") + s"$prefixString ${only.show.mkString(" ")}")
-          case _ =>
-            theme.sectionHeading("Usage:") :: usages.flatMap(us =>
-              us.show.map(line => withIndent(4, prefixString + " " + line))
-            )
-        }
+        theme.sectionHeading("Usage:") :: usages.flatMap(us =>
+          us.show.map(line => withIndent(4, prefixString + " " + line))
+        )
       }
 
     val errorsSection =
@@ -206,6 +200,7 @@ object Help extends BinCompat {
         description = parser.header
       )
     )
+
   }
 
   /**

--- a/core/shared/src/main/scala/com/monovore/decline/Help.scala
+++ b/core/shared/src/main/scala/com/monovore/decline/Help.scala
@@ -79,9 +79,15 @@ class Help private (
     val usageSection =
       if (usages.isEmpty || !format.usageEnabled) Nil
       else {
-        theme.sectionHeading("Usage:") :: usages.flatMap(us =>
-          us.show.map(line => withIndent(4, prefixString + " " + line))
-        )
+        usages.flatMap(us => us.show) match {
+          case Nil => List(theme.sectionHeading("Usage: ") + prefixString)
+          case only :: Nil =>
+            List(theme.sectionHeading("Usage: ") + s"$prefixString $only")
+          case _ =>
+            theme.sectionHeading("Usage:") :: usages.flatMap(us =>
+              us.show.map(line => withIndent(4, prefixString + " " + line))
+            )
+        }
       }
 
     val errorsSection =

--- a/core/shared/src/test/scala/com/monovore/decline/HelpSpec.scala
+++ b/core/shared/src/test/scala/com/monovore/decline/HelpSpec.scala
@@ -44,7 +44,8 @@ class HelpSpec extends AnyWordSpec with Matchers {
 
       Help.fromCommand(parser).toString should equal(
         """
-          |Usage: program [--first] [--second <integer>] [--third <integer>] [--flagOpt[=<string>]] --flag[=<string>] [--flag[=<string>]]... run
+          |Usage:
+          |    program [--first] [--second <integer>] [--third <integer>] [--flagOpt[=<string>]] --flag[=<string>] [--flag[=<string>]]... run
           |
           |A header.
           |
@@ -126,7 +127,9 @@ class HelpSpec extends AnyWordSpec with Matchers {
       }
 
       Help.fromCommand(parser).show should equal(
-        """|Usage: program-test --foo <string> --bar <string> --baz <string>
+        """|Usage:
+           |    program-test --foo <string>
+           |    program-test --bar <string> --baz <string>
            |
            |A header
            |
@@ -160,25 +163,26 @@ class HelpSpec extends AnyWordSpec with Matchers {
       }
 
       Help.fromCommand(parser).show should equal(
-        """|Usage: program-test [--first] [--second <integer>] [--third <integer>] run
-           |
-           |A header
-           |
-           |Options and flags:
-           |    --first, -F
-           |        First option.
-           |    --second <integer>
-           |        Second option.
-           |    --third <integer>
-           |        Third option.
-           |
-           |Environment Variables:
-           |    THIRD=<integer>
-           |        Third option env.
-           |
-           |Subcommands:
-           |    run
-           |        Run a task?""".stripMargin
+        """Usage:
+            |    program-test [--first] [--second <integer>] [--third <integer>] run
+            |
+            |A header
+            |
+            |Options and flags:
+            |    --first, -F
+            |        First option.
+            |    --second <integer>
+            |        Second option.
+            |    --third <integer>
+            |        Third option.
+            |
+            |Environment Variables:
+            |    THIRD=<integer>
+            |        Third option env.
+            |
+            |Subcommands:
+            |    run
+            |        Run a task?""".stripMargin
       )
     }
 
@@ -205,14 +209,11 @@ class HelpSpec extends AnyWordSpec with Matchers {
         .fromCommand(parser)
         .render(
           Help.Plain
-            .withOptions(false)
-            .withEnv(false)
-            .withCommands(false)
         ) should equal(
-        """
-        |Usage: program-test [--first] [--second <integer>] [--third <integer>] run
-        |
-        |A header""".stripMargin.trim()
+        """Usage:
+            |    program-test [--first] [--second <integer>] [--third <integer>] run
+            |
+            |A header""".stripMargin
       )
     }
 

--- a/core/shared/src/test/scala/com/monovore/decline/HelpSpec.scala
+++ b/core/shared/src/test/scala/com/monovore/decline/HelpSpec.scala
@@ -44,8 +44,7 @@ class HelpSpec extends AnyWordSpec with Matchers {
 
       Help.fromCommand(parser).toString should equal(
         """
-          |Usage:
-          |    program [--first] [--second <integer>] [--third <integer>] [--flagOpt[=<string>]] --flag[=<string>] [--flag[=<string>]]... run
+          |Usage: program [--first] [--second <integer>] [--third <integer>] [--flagOpt[=<string>]] --flag[=<string>] [--flag[=<string>]]... run
           |
           |A header.
           |
@@ -163,8 +162,7 @@ class HelpSpec extends AnyWordSpec with Matchers {
       }
 
       Help.fromCommand(parser).show should equal(
-        """Usage:
-            |    program-test [--first] [--second <integer>] [--third <integer>] run
+        """Usage: program-test [--first] [--second <integer>] [--third <integer>] run
             |
             |A header
             |
@@ -209,9 +207,11 @@ class HelpSpec extends AnyWordSpec with Matchers {
         .fromCommand(parser)
         .render(
           Help.Plain
+            .withOptions(false)
+            .withEnv(false)
+            .withCommands(false)
         ) should equal(
-        """Usage:
-            |    program-test [--first] [--second <integer>] [--third <integer>] run
+        """Usage: program-test [--first] [--second <integer>] [--third <integer>] run
             |
             |A header""".stripMargin
       )

--- a/core/shared/src/test/scala/com/monovore/decline/HelpSpec.scala
+++ b/core/shared/src/test/scala/com/monovore/decline/HelpSpec.scala
@@ -111,6 +111,35 @@ class HelpSpec extends AnyWordSpec with Matchers {
       help(foo) shouldBe help((foo, foo).tupled)
     }
 
+    "correctly display mutual exclusion" in {
+
+      val parser = Command(
+        name = "program-test",
+        header = "A header",
+        helpFlag = false
+      ) {
+        val fooOpt = Opts.option[String]("foo", help = "foo option")
+        val barOpt = Opts.option[String]("bar", help = "bar option")
+        val bazOpt = Opts.option[String]("baz", help = "baz option")
+
+        fooOpt `orElse` (barOpt, bazOpt).mapN { (str1, str2) => s"${str1} and ${str2}" }
+      }
+
+      Help.fromCommand(parser).show should equal(
+        """|Usage: program-test --foo <string> --bar <string> --baz <string>
+           |
+           |A header
+           |
+           |Options and flags:
+           |    --foo <string>
+           |        foo option
+           |    --bar <string>
+           |        bar option
+           |    --baz <string>
+           |        baz option""".stripMargin
+      )
+    }
+
     "work with Show instance" in {
       val parser = Command(
         name = "program-test",


### PR DESCRIPTION
Fixes the bug in #654 where multi-line usages were getting crammed onto a single line. This was due to a misunderstanding of a (confusing) part of usage rendering... where a single `Usage` instance may in practice expand out to multiple lines. (cc @keynmol) This preserves the intent of the change from the recent commit but fixes the behaviour for mutually exclusive options and similar things.